### PR TITLE
Remove hard-coded secret key in api.auth

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 *.pyc
 __pycache__
 docker/db/data
+.env

--- a/README.md
+++ b/README.md
@@ -48,6 +48,15 @@ use it with other tools: http://localhost:8001/openapi.json
 
 ## Authentication
 
+### Generate SECRET KEY and add it in environment file
+Generate a new key for Authentication using following command:
+```
+$ openssl rand -hex 32
+```
+Store the generated key to .env file and give its path to docker-compose.yaml file.
+We have loaded secret key using FastAPI settings feature in api.auth
+Please find the env.sample file in the base directory to store secret key and copy the file to your .env file.
+
 Some parts of the API require the user to be authenticated, for example to
 submit data to store in the database or access restricted data.  The first
 thing to do is create a user account.  For example, with a user called `bob`

--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -13,6 +13,8 @@ services:
       - '../api:/home/kernelci/api'
     ports:
       - '8001:8000'
+    env_file:
+      - ../.env
   db:
     container_name: 'kernelci-db'
     image: 'mongo:5.0'

--- a/env.sample
+++ b/env.sample
@@ -1,0 +1,1 @@
+SECRET_KEY=


### PR DESCRIPTION
1. Remove hard-coded secret key in api.auth and load it from the settings instead
2. Created secret key using openssl command and stored it in newly created .env file
3. Added an environment .env file to docker-compose.yaml
4. Updated README.md with instructions to create the key and store it in the .env file