### PR TITLE
Load all api.auth parameters from Settings and add documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,14 @@ submit data to store in the database or access restricted data.  The first
 thing to do is create a user account.  For example, with a user called `bob`
 and a password `hello`:
 
+### Set ALGORITHM and ACCESS_TOKEN_EXPIRE_MINUTES in environment file
+
+We need to specify algorithm for JWT token encoding and decoding. ALGORITHM variable needs to be passed in the parameter for that.
+ALGORITHM is set default to HS256.
+We have used ACCESS_TOKEN_EXPIRE_MINUTES variable to set expiry time on generated jwt access token.	
+ACCESS_TOKEN_EXPIRE_MINUTES is set default to None.
+If user wants to change any of the above variable, It should be added to .env file. Please refer env.sample to add variable to .env file.
+
 ### Get a password hash
 
 The passwords are not stored in clear in the database, instead a hash of them

--- a/api/auth.py
+++ b/api/auth.py
@@ -22,14 +22,12 @@ class TokenData(BaseModel):
 
 class Settings(BaseSettings):
     secret_key: str
+    algorithm: str = "HS256"
+    # Set to None so tokens don't expire
+    access_token_expire_minutes: float = None
 
 
 class Authentication:
-
-    ALGORITHM = "HS256"
-
-    # Set to None so tokens don't expire
-    ACCESS_TOKEN_EXPIRE_MINUTES = None  # 30
 
     def __init__(self, db):
         self._pwd_context = CryptContext(schemes=["bcrypt"], deprecated="auto")
@@ -49,18 +47,25 @@ class Authentication:
 
     def create_access_token(self, data: dict):
         to_encode = data.copy()
-        if self.ACCESS_TOKEN_EXPIRE_MINUTES:
-            expires_delta = timedelta(minutes=self.ACCESS_TOKEN_EXPIRE_MINUTES)
+        if self._settings.access_token_expire_minutes:
+            expires_delta = timedelta(
+                    minutes=self._settings.access_token_expire_minutes
+                    )
             expire = datetime.utcnow() + expires
             to_encode.update({"exp": expire})
         encoded_jwt = jwt.encode(
-            to_encode, self._settings.secret_key, algorithm=self.ALGORITHM)
+            to_encode,
+            self._settings.secret_key, algorithm=self._settings.algorithm
+            )
         return encoded_jwt
 
     def get_current_user(self, token):
         try:
             payload = jwt.decode(
-                token, self._settings.secret_key, algorithms=[self.ALGORITHM])
+                    token,
+                    self._settings.secret_key,
+                    algorithms=[self._settings.algorithm]
+                    )
             username: str = payload.get("sub")
             if username is None:
                 return None

--- a/env.sample
+++ b/env.sample
@@ -1,1 +1,3 @@
 SECRET_KEY=
+#algorithm=
+#access_token_expire_minutes=


### PR DESCRIPTION
api/auth.py : Move ALGORITHM and ACCESS_TOKEN_EXPIRE_MINUTES to the Settings class with default values
env.sample : Add the ACCESS_TOKEN_EXPIRE_MINUTES and ALGORITHM variables to env.sample but commented-out, in case the user wants to override them
README.md : Add a mention in the README file about these settings

Signed-off-by: Jeny Sadadia <jeny.sadadia@gmail.com>