### PR TITLE
docker: use Python 3.10 for the API container

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ubuntu-20.04
     strategy:
       matrix:
-        python-version: [3.6, 3.9]
+        python-version: ['3.6', '3.10']
 
     steps:
 

--- a/docker/api/Dockerfile
+++ b/docker/api/Dockerfile
@@ -3,7 +3,7 @@
 # Copyright (C) 2021 Collabora Limited
 # Author: Guillaume Tucker <guillaume.tucker@collabora.com>
 
-FROM python:3.8
+FROM python:3.10
 MAINTAINER "KernelCI TSC" <kernelci-tsc@groups.io>
 
 # Upgrade pip3 - never mind the warning about running this as root


### PR DESCRIPTION
Use Python 3.10 rather than 3.8 for the KernelCI API container as all
the components are compatible.  Extend the GitHub checks to Python
3.10 as well.

Signed-off-by: Guillaume Tucker <guillaume.tucker@collabora.com>