### PR TITLE
api.pubsub: add .publish_cloudevent() method

### DIFF
--- a/api/main.py
+++ b/api/main.py
@@ -3,7 +3,6 @@
 # Copyright (C) 2021 Collabora Limited
 # Author: Guillaume Tucker <guillaume.tucker@collabora.com>
 
-from cloudevents.http import CloudEvent, to_json
 from fastapi import Depends, FastAPI, HTTPException, status
 from fastapi.security import OAuth2PasswordBearer, OAuth2PasswordRequestForm
 from .auth import Authentication, Token
@@ -120,5 +119,4 @@ async def listen(channel: str, user: User = Depends(get_user)):
 async def publish(raw: dict, channel: str, user: User = Depends(get_user)):
     attributes = dict(raw)
     data = attributes.pop('data')
-    event = CloudEvent(attributes=attributes, data=data)
-    await pubsub.publish(user, channel, to_json(event))
+    await pubsub.publish_cloudevent(channel, attributes, data)


### PR DESCRIPTION
Add PubSub.publish_cloudevent() method and move the cloudevent
wrapping code from api.main to api.pubsub.  This will allow other
parts of the code to generate CloudEvents by using api.pubsub
directly.

Signed-off-by: Guillaume Tucker <guillaume.tucker@collabora.com>