### PR TITLE
T31494 Pub/Sub IDs

### DIFF
--- a/api/main.py
+++ b/api/main.py
@@ -8,7 +8,7 @@ from fastapi.security import OAuth2PasswordBearer, OAuth2PasswordRequestForm
 from .auth import Authentication, Token
 from .db import Database
 from .models import Thing, User
-from .pubsub import PubSub
+from .pubsub import PubSub, Subscription
 
 app = FastAPI()
 db = Database()
@@ -90,7 +90,7 @@ async def create_thing(thing: Thing, token: str = Depends(get_current_user)):
 # -----------------------------------------------------------------------------
 # Pub/Sub
 
-@app.post('/subscribe/{channel}')
+@app.post('/subscribe/{channel}', response_model=Subscription)
 async def subscribe(channel: str, user: User = Depends(get_user)):
     return await pubsub.subscribe(channel)
 

--- a/api/pubsub.py
+++ b/api/pubsub.py
@@ -6,11 +6,16 @@
 import aioredis
 import asyncio
 from cloudevents.http import CloudEvent, to_json
-from pydantic import BaseSettings
+from pydantic import BaseModel, BaseSettings
 
 
 class Settings(BaseSettings):
     cloud_events_source: str = "https://api.kernelci.org/"
+
+
+class Subscription(BaseModel):
+    id: int
+    channel: str
 
 
 class PubSub:
@@ -37,7 +42,7 @@ class PubSub:
             sub = self._redis.pubsub()
             self._subscriptions[sub_id] = sub
             await sub.subscribe(channel)
-            return sub_id
+            return Subscription(id=sub_id, channel=channel)
 
     async def unsubscribe(self, sub_id):
         async with self._lock:


### PR DESCRIPTION
Add unique IDs for each Pub/Sub subscription rather than rely on user / channel combinations.  The IDs are managed with an int stored in Redis.

Fixes #26 