### PR TITLE
api.main: deal with 'None' token

### DIFF
--- a/api/main.py
+++ b/api/main.py
@@ -24,6 +24,12 @@ async def pubsub_startup():
 
 
 async def get_current_user(token: str = Depends(oauth2_scheme)):
+    if token == 'None':
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Missing credentials",
+            headers={"WWW-Authenticate": "Bearer"},
+        )
     user = await auth.get_current_user(token)
     if user is None:
         raise HTTPException(


### PR DESCRIPTION
Deal with API calls that set the token value to 'None' by returning
HTTP 401.  This may happen by converting a None object to a string on
the client side, and it will then get converted to a NoneType object
on the API side and cause an exception in oauth2_scheme.

Signed-off-by: Guillaume Tucker <guillaume.tucker@collabora.com>