### PR TITLE
api.auth: fix async call to .get_current_user()

### DIFF
--- a/api/auth.py
+++ b/api/auth.py
@@ -59,13 +59,13 @@ class Authentication:
             )
         return encoded_jwt
 
-    def get_current_user(self, token):
+    async def get_current_user(self, token):
         try:
             payload = jwt.decode(
-                    token,
-                    self._settings.secret_key,
-                    algorithms=[self._settings.algorithm]
-                    )
+                token,
+                self._settings.secret_key,
+                algorithms=[self._settings.algorithm]
+            )
             username: str = payload.get("sub")
             if username is None:
                 return None
@@ -73,4 +73,4 @@ class Authentication:
         except JWTError:
             return None
 
-        return self._db.find_one(User, username=token_data.username)
+        return await self._db.find_one(User, username=token_data.username)


### PR DESCRIPTION
The Authentication.get_current_user() method does a database query
which is asynchronous.  As such, declare the method as async and use
await when quering the database.

Signed-off-by: Guillaume Tucker <guillaume.tucker@collabora.com>