### PR TITLE
api.db: fix obj.id check

### DIFF
--- a/api/db.py
+++ b/api/db.py
@@ -42,9 +42,10 @@ class Database(object):
         return model(**obj) if obj else None
 
     async def create(self, obj):
+        if obj.id is not None:
+            raise ValueError(f"Object cannot be created with id: {obj.id}")
+        delattr(obj, 'id')
         col = self._get_collection(obj.__class__)
-        if hasattr(obj, 'id'):
-            delattr(obj, 'id')
         res = await col.insert_one(obj.dict(by_alias=True))
         obj.id = res.inserted_id
         return obj


### PR DESCRIPTION
The objects passed to Database.create() always have a .id attribute as
it's defined in the Pydantic models.  However, it should be None in
the case of a new object since it hasn't been saved in the database
yet.  As such, fix the check to only create objects when the .id is
None.

Fixes: 54f51945e591 ("api: add api.db.Database() abstraction class")
Signed-off-by: Guillaume Tucker <guillaume.tucker@collabora.com>