### PR TITLE
api.models: add Revision.url and .describe

### DIFF
--- a/api/models.py
+++ b/api/models.py
@@ -52,8 +52,10 @@ class Thing(ModelId):
 
 class Revision(BaseModel):
     tree: str
+    url: str
     branch: str
     commit: str
+    describe: str
 
 
 class Node(ModelId):


### PR DESCRIPTION
Add .url and .describe fields to the Revision model, to contain the
Git URL and Git describe strings.  This should help align with the
current bmeta.json schema used by kernelci-core.

Part of #37 