### PR TITLE
Run kernelci-api test with Github Actions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -34,3 +34,18 @@ jobs:
       - name: Run pycodestyle
         run: |
           pycodestyle api/*.py
+
+      - name: Install python packages
+        working-directory: docker/api
+        run: |
+          python -m pip install --upgrade pip
+          chmod +x installPackagesDev.sh 
+          ./installPackagesDev.sh
+
+      - name: Export environment variable
+        run: |
+          echo "SECRET_KEY=$(openssl rand -hex 32)" >> $GITHUB_ENV
+
+      - name: Run pytest
+        run: |
+          pytest -v api/


### PR DESCRIPTION
Fixes https://github.com/kernelci/kernelci-api/issues/44

.github/workflows/main.yml: Added steps to run pytest for kernelci-api
api/__init__.py: Add file to make api a package
api/test_api.py: Add file with root endpoint test case
docker/api/requirements-dev.txt: Add file with python test packages

Signed-off-by: Jeny Sadadia <jeny.sadadia@gmail.com>