### PR TITLE
Run Pylint on api.models using GitHub actions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -43,6 +43,10 @@ jobs:
         run: |
           pycodestyle api/*.py
 
+      - name: Run pylint
+        run: |
+          pylint -d R0903 api.models
+
       - name: Export environment variables
         run: |
           echo "SECRET_KEY=$(openssl rand -hex 32)" >> $GITHUB_ENV

--- a/api/models.py
+++ b/api/models.py
@@ -3,12 +3,16 @@
 # Copyright (C) 2021 Collabora Limited
 # Author: Guillaume Tucker <guillaume.tucker@collabora.com>
 
+"""KernelCI API model definitions"""
+
+from typing import Optional
+
 from bson import ObjectId
 from pydantic import BaseModel, Field
-from typing import Optional
 
 
 class PyObjectId(ObjectId):
+    """Wrapper around ObjectId to be able to use it in Pydantic models"""
 
     @classmethod
     def __get_validators__(cls):
@@ -19,16 +23,25 @@ class PyObjectId(ObjectId):
         field_schema.update(type='string')
 
     @classmethod
-    def validate(cls, v):
-        if not ObjectId.is_valid(v):
+    def validate(cls, value):
+        """Validate the value of the ObjectId"""
+        if not ObjectId.is_valid(value):
             raise ValueError('Invalid ObjectId')
-        return ObjectId(v)
+        return ObjectId(value)
 
 
 class ModelId(BaseModel):
+    """Pydantic model including a .id attribute for the Mongo DB _id
+
+    This Pydantic model class is a thin wrapper around `pydantic.BaseModel`
+    with an added `.id` attribute which then gets translated to the `_id`
+    attribute in Mongo DB documents using the `PyObjectId` class.
+    """
+
     id: Optional[PyObjectId] = Field(alias='_id')
 
     class Config:
+        """Configuration attributes for ModelId"""
         arbitrary_types_allowed = True
         json_encoders = {
             ObjectId: str,
@@ -40,17 +53,20 @@ class ModelId(BaseModel):
 #
 
 class User(ModelId):
+    """API user model"""
     username: str
     hashed_password: str
     active: bool
 
 
 class Thing(ModelId):
+    """Thing object model for early experiments with Fast API and Mongo DB"""
     name: str
     value: int
 
 
 class Revision(BaseModel):
+    """Linux kernel Git revision model"""
     tree: str
     url: str
     branch: str
@@ -59,6 +75,7 @@ class Revision(BaseModel):
 
 
 class Node(ModelId):
+    """KernelCI primitive node object model for generic test results"""
     kind: str = 'node'
     name: str
     revision: Revision

--- a/docker/api/requirements-dev.txt
+++ b/docker/api/requirements-dev.txt
@@ -1,4 +1,5 @@
 -r requirements.txt
 pycodestyle==2.8.0
+pylint==2.12.2
 pytest==6.2.5
 pytest-mock==3.6.1


### PR DESCRIPTION
Add a check in the GitHub actions to run Pylint on `api.models` and fix all the errors reported by it so the score is 10.0.  Ignore warnings about the number of public methods on classes as model classes don't have any methods by design.

Other modules in the `api` package should be added as a follow-up in the same way.