### PR TITLE
Fix GitHub actions running checks

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -36,8 +36,7 @@ jobs:
         working-directory: docker/api
         run: |
           python -m pip install --upgrade pip
-          chmod +x installPackagesDev.sh
-          ./installPackagesDev.sh
+          pip install -r requirements-dev.txt
 
       - name: Run pycodestyle
         run: |

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -35,6 +35,7 @@ jobs:
       - name: Install Python packages
         working-directory: docker/api
         run: |
+          python --version
           python -m pip install --upgrade pip
           pip install -r requirements-dev.txt
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -17,32 +17,33 @@ on:
 jobs:
   check:
     runs-on: ubuntu-20.04
+
     strategy:
       matrix:
-        python-version: ['3.6', '3.10']
+        python-version: ['3.10'] # Only supported one at the moment
 
     steps:
 
-      # Checks out the repository under $GITHUB_WORKSPACE
-      - uses: actions/checkout@v2
+      - name: Check out source code
+        uses: actions/checkout@v2
 
-      - name: Install Debian dependencies
+      - name: Set up Python
+        uses: actions/setup-python@master
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Install Python packages
+        working-directory: docker/api
         run: |
-          sudo apt update
-          sudo apt install -y pycodestyle
+          python -m pip install --upgrade pip
+          chmod +x installPackagesDev.sh
+          ./installPackagesDev.sh
 
       - name: Run pycodestyle
         run: |
           pycodestyle api/*.py
 
-      - name: Install python packages
-        working-directory: docker/api
-        run: |
-          python -m pip install --upgrade pip
-          chmod +x installPackagesDev.sh 
-          ./installPackagesDev.sh
-
-      - name: Export environment variable
+      - name: Export environment variables
         run: |
           echo "SECRET_KEY=$(openssl rand -hex 32)" >> $GITHUB_ENV
 

--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ and a password `hello`:
 
 We need to specify algorithm for JWT token encoding and decoding. ALGORITHM variable needs to be passed in the parameter for that.
 ALGORITHM is set default to HS256.
-We have used ACCESS_TOKEN_EXPIRE_MINUTES variable to set expiry time on generated jwt access token.	
+We have used ACCESS_TOKEN_EXPIRE_MINUTES variable to set expiry time on generated jwt access token.
 ACCESS_TOKEN_EXPIRE_MINUTES is set default to None.
 If user wants to change any of the above variable, It should be added to .env file. Please refer env.sample to add variable to .env file.
 
@@ -230,9 +230,9 @@ has all the Python dependencies installed (essentially, `cloudevents`).
 
 Please follow below instructions to test API endpoints.
 
-Run installPackagesDev.sh script from kernelci-api/docker/api directory to install all the required packages from requirements.txt and requirements-dev.txt:
+Install Python requirements with additional packages for testing:
 ```
-./installPackagesDev.sh
+pip install -r docker/api/requirements-dev.txt
 ```
 
 We have created .env file using env.sample in kernelci-api directory from 'Generate SECRET KEY and add it in environment file' section. Export .env file with SECRET_KEY environment variable in it:

--- a/docker/api/installPackagesDev.sh
+++ b/docker/api/installPackagesDev.sh
@@ -1,1 +1,0 @@
-pip install -r requirements.txt -r requirements-dev.txt

--- a/docker/api/installPackagesProduction.sh
+++ b/docker/api/installPackagesProduction.sh
@@ -1,1 +1,0 @@
-pip install -r requirements.txt

--- a/docker/api/requirements-dev.txt
+++ b/docker/api/requirements-dev.txt
@@ -1,2 +1,3 @@
+pycodestyle==2.8.0
 pytest==6.2.5
 pytest-mock==3.6.1

--- a/docker/api/requirements-dev.txt
+++ b/docker/api/requirements-dev.txt
@@ -1,3 +1,4 @@
+-r requirements.txt
 pycodestyle==2.8.0
 pytest==6.2.5
 pytest-mock==3.6.1


### PR DESCRIPTION
Use `actions/setup-python` to install the actual Python version required, and reduce to only testing with Python 3.10 as it's the only version that actually works with all the current requirements.  Also consolidate how requirements-dev.txt is used to simplify things.