### PR TITLE
docker: add REQUIREMENTS build argument

### DIFF
--- a/docker/api/Dockerfile
+++ b/docker/api/Dockerfile
@@ -18,7 +18,8 @@ ENV PATH=$PATH:/home/kernelci/.local/bin
 WORKDIR /home/kernelci
 
 # Install requirements
-COPY requirements.txt /home/kernelci/
-RUN pip install --requirement requirements.txt
+COPY requirements*.txt /home/kernelci/
+ARG REQUIREMENTS=requirements.txt
+RUN pip install --requirement ${REQUIREMENTS}
 
 CMD ["uvicorn", "api.main:app", "--host", "0.0.0.0", "--reload"]

--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -10,6 +10,8 @@ services:
     container_name: 'kernelci-api'
     build:
       context: api
+      args:
+        - REQUIREMENTS=${REQUIREMENTS:-requirements.txt}
     volumes:
       - '../api:/home/kernelci/api'
     ports:


### PR DESCRIPTION
Add a build argument ${REQUIREMENTS} which defaults to
requirements.txt but can be overridden by an environment variable at
build time to specify an alternative requirements file.  For example,
to start docker-compose with the development tools installed in the
API container:

  REQUIREMENTS=requirements-dev.txt docker-compose up --build

Signed-off-by: Guillaume Tucker <guillaume.tucker@collabora.com>