### PR TITLE
api/test_api.py: Add /subscribe endpoint test

### DIFF
--- a/api/test_api.py
+++ b/api/test_api.py
@@ -134,3 +134,11 @@ def mock_init_sub_id(mocker):
     mocker.patch('api.pubsub.PubSub._init_sub_id',
                  side_effect=async_mock)
     return async_mock
+
+
+@pytest.fixture()
+def mock_subscribe(mocker):
+    async_mock = AsyncMock()
+    mocker.patch('api.pubsub.PubSub.subscribe',
+                 side_effect=async_mock)
+    return async_mock

--- a/api/test_api.py
+++ b/api/test_api.py
@@ -126,3 +126,11 @@ def test_token_endpoint_incorrect_password(mock_db_find_one):
     print("response json", response.json())
     assert response.status_code == 401
     assert response.json() == {'detail': 'Incorrect username or password'}
+
+
+@pytest.fixture()
+def mock_init_sub_id(mocker):
+    async_mock = AsyncMock()
+    mocker.patch('api.pubsub.PubSub._init_sub_id',
+                 side_effect=async_mock)
+    return async_mock

--- a/api/test_api.py
+++ b/api/test_api.py
@@ -8,6 +8,7 @@ from .main import app
 from .models import User
 from fastapi.testclient import TestClient
 from unittest.mock import AsyncMock
+from .pubsub import Subscription
 
 
 @pytest.fixture
@@ -142,3 +143,36 @@ def mock_subscribe(mocker):
     mocker.patch('api.pubsub.PubSub.subscribe',
                  side_effect=async_mock)
     return async_mock
+
+
+def test_subscribe_endpoint(mock_get_current_user, mock_init_sub_id,
+                            mock_subscribe):
+    """
+    Test Case : Test KernelCI API /subscribe endpoint
+    Expected Result :
+        HTTP Response Code 200 OK
+        JSON with 'id' and 'channel' keys
+    """
+    user = User(username='bob',
+                hashed_password='$2b$12$CpJZx5ooxM11bCFXT76/z.o6HWs2sPJy4iP8.'
+                                'xCZGmM8jWXUXJZ4K',
+                active=True)
+    mock_get_current_user.return_value = user
+
+    subscribe = Subscription(id=1, channel='abc')
+    mock_subscribe.return_value = subscribe
+
+    with TestClient(app) as client:
+        # Use context manager to trigger a startup event on the app object
+        response = client.post(
+            "/subscribe/abc",
+            headers={
+                "Authorization": "Bearer "
+                "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9."
+                "eyJzdWIiOiJib2IifQ.ci1smeJeuX779PptTkuaG1S"
+                "Edkp5M1S1AgYvX8VdB20"
+            },
+        )
+        print("response.json()", response.json())
+        assert response.status_code == 200
+        assert ('id' and 'channel') in response.json()


### PR DESCRIPTION
Fixes: https://github.com/kernelci/kernelci-api/issues/68

api/test_api.py: Add fixture to mock PubSub._init_sub_id
api/test_api.py: Add fixture to mock PubSub.subscribe
api/test_api.py:  Add test_subscribe_endpoint

Signed-off-by: Jeny Sadadia <jeny.sadadia@gmail.com>