### PR TITLE
api/test_api.py: Add test cases for /unsubscribe endpoint

### DIFF
--- a/api/test_api.py
+++ b/api/test_api.py
@@ -211,3 +211,32 @@ def test_unsubscribe_endpoint(mock_get_current_user,
             },
         )
         assert response.status_code == 200
+
+
+def test_unsubscribe_endpoint_empty_response(mock_get_current_user,
+                                             mock_init_sub_id):
+    """
+    Test Case : Test KernelCI API /unsubscribe endpoint negative path
+    Expected Result :
+        HTTP Response Code 204 HTTP_204_NO_CONTENT
+        JSON with 'detail' key
+    """
+    user = User(username='bob',
+                hashed_password='$2b$12$CpJZx5ooxM11bCFXT76/z.o6HWs2sPJy4iP8.'
+                                'xCZGmM8jWXUXJZ4K',
+                active=True)
+    mock_get_current_user.return_value = user
+
+    with TestClient(app) as client:
+        response = client.post(
+            "/unsubscribe/1",
+            headers={
+                "Authorization": "Bearer "
+                "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9."
+                "eyJzdWIiOiJib2IifQ.ci1smeJeuX779PptTkuaG1S"
+                "Edkp5M1S1AgYvX8VdB20"
+            },
+        )
+        print("response.json()", response.json())
+        assert response.status_code == 204
+        assert 'detail' in response.json()

--- a/api/test_api.py
+++ b/api/test_api.py
@@ -145,6 +145,14 @@ def mock_subscribe(mocker):
     return async_mock
 
 
+@pytest.fixture()
+def mock_unsubscribe(mocker):
+    async_mock = AsyncMock()
+    mocker.patch('api.pubsub.PubSub.unsubscribe',
+                 side_effect=async_mock)
+    return async_mock
+
+
 def test_subscribe_endpoint(mock_get_current_user, mock_init_sub_id,
                             mock_subscribe):
     """
@@ -176,3 +184,30 @@ def test_subscribe_endpoint(mock_get_current_user, mock_init_sub_id,
         print("response.json()", response.json())
         assert response.status_code == 200
         assert ('id' and 'channel') in response.json()
+
+
+def test_unsubscribe_endpoint(mock_get_current_user,
+                              mock_init_sub_id, mock_unsubscribe):
+    """
+    Test Case : Test KernelCI API /unsubscribe endpoint positive path
+    Expected Result :
+        HTTP Response Code 200 OK
+    """
+    user = User(username='bob',
+                hashed_password='$2b$12$CpJZx5ooxM11bCFXT76/z.o6HWs2sPJy4iP8.'
+                                'xCZGmM8jWXUXJZ4K',
+                active=True)
+    mock_get_current_user.return_value = user
+    mock_unsubscribe.return_value = True
+
+    with TestClient(app) as client:
+        response = client.post(
+            "/unsubscribe/1",
+            headers={
+                "Authorization": "Bearer "
+                "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9."
+                "eyJzdWIiOiJib2IifQ.ci1smeJeuX779PptTkuaG1S"
+                "Edkp5M1S1AgYvX8VdB20"
+            },
+        )
+        assert response.status_code == 200


### PR DESCRIPTION
Fixes https://github.com/kernelci/kernelci-api/issues/69

Test case for /unsubscribe endpoint for the positive path
Test case for /unsubscribe endpoint for the negative path

Signed-off-by: Jeny Sadadia <jeny.sadadia@gmail.com>