### PR TITLE
Add test case to create node object

### DIFF
--- a/api/test_api.py
+++ b/api/test_api.py
@@ -248,3 +248,11 @@ def mock_db_create(mocker):
     mocker.patch('api.db.Database.create',
                  side_effect=async_mock)
     return async_mock
+
+
+@pytest.fixture()
+def mock_publish_cloudevent(mocker):
+    async_mock = AsyncMock()
+    mocker.patch('api.pubsub.PubSub.publish_cloudevent',
+                 side_effect=async_mock)
+    return async_mock

--- a/api/test_api.py
+++ b/api/test_api.py
@@ -240,3 +240,11 @@ def test_unsubscribe_endpoint_empty_response(mock_get_current_user,
         print("response.json()", response.json())
         assert response.status_code == 204
         assert 'detail' in response.json()
+
+
+@pytest.fixture()
+def mock_db_create(mocker):
+    async_mock = AsyncMock()
+    mocker.patch('api.db.Database.create',
+                 side_effect=async_mock)
+    return async_mock


### PR DESCRIPTION
Fixes https://github.com/kernelci/kernelci-api/issues/77

api/test_api.py: Add fixture to mock Database.create
api/test_api.py: Add fixture to mock PubSub.publish_cloudevent
api/test_api.py: Add test_create_node_endpoint to test POST /node endpoint

Signed-off-by: Jeny Sadadia <jeny.sadadia@gmail.com>