### PR TITLE
Add test for get node by ID endpoint

### DIFF
--- a/api/test_api.py
+++ b/api/test_api.py
@@ -431,3 +431,44 @@ def mock_db_find_by_id(mocker):
     mocker.patch('api.db.Database.find_by_id',
                  side_effect=async_mock)
     return async_mock
+
+
+def test_get_node_by_id_endpoint(mock_get_current_user, mock_db_find_by_id,
+                                 mock_init_sub_id):
+    """
+    Test Case : Test KernelCI API GET /node/{node_id} endpoint
+    for the positive path
+    Expected Result :
+        HTTP Response Code 200 OK
+        JSON with Node object attributes
+    """
+    user = User(username='bob',
+                hashed_password='$2b$12$CpJZx5ooxM11bCFXT76/z.o6HWs2sPJy4iP8.'
+                                'xCZGmM8jWXUXJZ4K',
+                active=True)
+    mock_get_current_user.return_value = user
+
+    revision_obj = Revision(
+                tree="mainline",
+                url="https://git.kernel.org/pub/scm/linux/kernel/git/"
+                    "torvalds/linux.git",
+                branch="master",
+                commit="2a987e65025e2b79c6d453b78cb5985ac6e5eb26",
+                describe="v5.16-rc4-31-g2a987e65025e"
+    )
+    node_obj = Node(
+            _id="61bda8f2eb1a63d2b7152418",
+            kind="node",
+            name="checkout",
+            revision=revision_obj,
+            parent=None,
+            status=None
+        )
+    mock_db_find_by_id.return_value = node_obj
+
+    with TestClient(app) as client:
+        response = client.get("/node/61bda8f2eb1a63d2b7152418")
+        print("response.json()", response.json())
+        assert response.status_code == 200
+        assert ('_id' and 'kind' and 'name' and
+                'revision' and 'parent' and 'status') in response.json()

--- a/api/test_api.py
+++ b/api/test_api.py
@@ -423,3 +423,11 @@ def test_get_node_by_attributes_endpoint_node_not_found(
         print("response.json()", response.json())
         assert response.status_code == 200
         assert len(response.json()) == 0
+
+
+@pytest.fixture()
+def mock_db_find_by_id(mocker):
+    async_mock = AsyncMock()
+    mocker.patch('api.db.Database.find_by_id',
+                 side_effect=async_mock)
+    return async_mock

--- a/api/test_api.py
+++ b/api/test_api.py
@@ -472,3 +472,39 @@ def test_get_node_by_id_endpoint(mock_get_current_user, mock_db_find_by_id,
         assert response.status_code == 200
         assert ('_id' and 'kind' and 'name' and
                 'revision' and 'parent' and 'status') in response.json()
+
+
+def test_get_node_by_id_endpoint_empty_response(mock_get_current_user,
+                                                mock_db_find_by_id,
+                                                mock_init_sub_id):
+    """
+    Test Case : Test KernelCI API GET /node/{node_id} endpoint
+    for negative path
+    Expected Result :
+        HTTP Response Code 200 OK
+        Response JSON None
+    """
+    user = User(username='bob',
+                hashed_password='$2b$12$CpJZx5ooxM11bCFXT76/z.o6HWs2sPJy4iP8.'
+                                'xCZGmM8jWXUXJZ4K',
+                active=True)
+    mock_get_current_user.return_value = user
+
+    mock_db_find_by_id.return_value = None
+
+    with TestClient(app) as client:
+        request_dict = {
+            "name": "checkout",
+            "revision": {
+                "tree": "mainline",
+                "url": "https://git.kernel.org/pub/scm/linux/kernel/git/"
+                        "torvalds/linux.git",
+                "branch": "master",
+                "commit": "2a987e65025e2b79c6d453b78cb5985ac6e5eb26",
+                "describe": "v5.16-rc4-31-g2a987e65025e"
+                }
+            }
+        response = client.get("/node/61bda8f2eb1a63d2b7152419")
+        print("response.json()", response.json())
+        assert response.status_code == 200
+        assert response.json() is None


### PR DESCRIPTION
Fixes https://github.com/kernelci/kernelci-api/issues/79

api/test_api.py: Add fixture for Database.find_by_id
api/test_api.py: Add test_get_node_by_id_endpoint_positive
api/test_api.py: Add test_get_node_by_id_endpoint_negative

Signed-off-by: Jeny Sadadia <jeny.sadadia@gmail.com>