### PR TITLE
Add test case for /nodes endpoint

### DIFF
--- a/api/test_api.py
+++ b/api/test_api.py
@@ -508,3 +508,76 @@ def test_get_node_by_id_endpoint_empty_response(mock_get_current_user,
         print("response.json()", response.json())
         assert response.status_code == 200
         assert response.json() is None
+
+
+def test_get_all_nodes(mock_get_current_user, mock_db_find_by_attributes,
+                       mock_init_sub_id):
+    """
+    Test Case : Test KernelCI API GET /nodes endpoint for the
+    positive path
+    Expected Result :
+        HTTP Response Code 200 OK
+        List of all the node objects.
+    """
+    user = User(username='bob',
+                hashed_password='$2b$12$CpJZx5ooxM11bCFXT76/z.o6HWs2sPJy4iP8.'
+                                'xCZGmM8jWXUXJZ4K',
+                active=True)
+    mock_get_current_user.return_value = user
+
+    revision_obj_1 = Revision(
+                tree="mainline",
+                url="https://git.kernel.org/pub/scm/linux/kernel/git/"
+                    "torvalds/linux.git",
+                branch="master",
+                commit="2a987e65025e2b79c6d453b78cb5985ac6e5eb26",
+                describe="v5.16-rc4-31-g2a987e65025e"
+                )
+    node_obj_1 = Node(
+            _id="61bda8f2eb1a63d2b7152418",
+            kind="node",
+            name="checkout",
+            revision=revision_obj_1,
+            parent=None,
+            status=None
+        )
+    revision_obj_2 = Revision(
+                tree="mainline",
+                url="https://git.kernel.org/pub/scm/linux/kernel/git/"
+                    "torvalds/linux.git",
+                branch="master",
+                commit="2a987e65025e2b79c6d453b78cb5985ac6e5eb45",
+                describe="v5.16-rc4-31-g2a987e65025e"
+                )
+    node_obj_2 = Node(
+            _id="61bda8f2eb1a63d2b7152414",
+            kind="node",
+            name="test_node",
+            revision=revision_obj_2,
+            parent=None,
+            status=None
+        )
+    revision_obj_3 = Revision(
+                tree="baseline",
+                url="https://git.kernel.org/pub/scm/linux/kernel/git/"
+                    "torvalds/linux.git",
+                branch="master",
+                commit="2a987e65025e2b79c6d453b78cb5985ac6e5eb26",
+                describe="v5.16-rc4-31-g2a987e65025e"
+                )
+    node_obj_3 = Node(
+            _id="61bda8f2eb1a63d2b7152421",
+            kind="node",
+            name="test",
+            revision=revision_obj_3,
+            parent=None,
+            status=None
+        )
+    mock_db_find_by_attributes.return_value = [node_obj_1, node_obj_2,
+                                               node_obj_3]
+
+    with TestClient(app) as client:
+        response = client.get("/nodes")
+        print("response.json()", response.json())
+        assert response.status_code == 200
+        assert len(response.json()) > 0

--- a/api/test_api.py
+++ b/api/test_api.py
@@ -581,3 +581,28 @@ def test_get_all_nodes(mock_get_current_user, mock_db_find_by_attributes,
         print("response.json()", response.json())
         assert response.status_code == 200
         assert len(response.json()) > 0
+
+
+def test_get_all_nodes_empty_response(mock_get_current_user,
+                                      mock_db_find_by_attributes,
+                                      mock_init_sub_id):
+    """
+    Test Case : Test KernelCI API GET /nodes endpoint for the
+    negative path
+    Expected Result :
+        HTTP Response Code 200 OK
+        Empty list as no Node object is added.
+    """
+    user = User(username='bob',
+                hashed_password='$2b$12$CpJZx5ooxM11bCFXT76/z.o6HWs2sPJy4iP8.'
+                                'xCZGmM8jWXUXJZ4K',
+                active=True)
+    mock_get_current_user.return_value = user
+
+    mock_db_find_by_attributes.return_value = []
+
+    with TestClient(app) as client:
+        response = client.get("/nodes")
+        print("response.json()", response.json())
+        assert response.status_code == 200
+        assert len(response.json()) == 0


### PR DESCRIPTION
Fixes https://github.com/kernelci/kernelci-api/issues/83

api/test_api.py: Add test_get_all_nodes_positive
api/test_api.py: Add test_get_all_nodes_negative

Signed-off-by: Jeny Sadadia <jeny.sadadia@gmail.com>