### PR TITLE
Add tests for api.pubsub.PubSub.unsubscribe()

### DIFF
--- a/test/test_pubsub.py
+++ b/test/test_pubsub.py
@@ -56,3 +56,12 @@ async def test_subscribe_multiple_channels(mock_pubsub):
     assert len(mock_pubsub._subscriptions) == 3
     assert (1, 2, 3) == tuple(mock_pubsub._subscriptions.keys())
 
+
+@pytest.fixture()
+def mock_pubsub_subscriptions(mocker):
+    pubsub = PubSub()
+    redis_mock = fakeredis.aioredis.FakeRedis()
+    mocker.patch.object(pubsub, '_redis', redis_mock)
+    subscriptions_mock = dict({1: pubsub._redis.pubsub()})
+    mocker.patch.object(pubsub, '_subscriptions', subscriptions_mock)
+    return pubsub

--- a/test/test_pubsub.py
+++ b/test/test_pubsub.py
@@ -65,3 +65,19 @@ def mock_pubsub_subscriptions(mocker):
     subscriptions_mock = dict({1: pubsub._redis.pubsub()})
     mocker.patch.object(pubsub, '_subscriptions', subscriptions_mock)
     return pubsub
+
+
+@pytest.mark.asyncio
+async def test_unsubscribe_sub_id_exists(mock_pubsub_subscriptions):
+    """
+    Test Case: Unsubscribe with a PubSub.unsubscribe() method when
+    subscription ID exists in subscriptions dictionary.
+
+    Expected Result:
+        PubSub._subscriptions dict should be empty.
+        Return value should be True.
+    """
+    # In case of subscription id exists
+    result = await mock_pubsub_subscriptions.unsubscribe(sub_id=1)
+    assert len(mock_pubsub_subscriptions._subscriptions) == 0
+    assert result is True

--- a/test/test_pubsub.py
+++ b/test/test_pubsub.py
@@ -81,3 +81,21 @@ async def test_unsubscribe_sub_id_exists(mock_pubsub_subscriptions):
     result = await mock_pubsub_subscriptions.unsubscribe(sub_id=1)
     assert len(mock_pubsub_subscriptions._subscriptions) == 0
     assert result is True
+
+
+@pytest.mark.asyncio
+async def test_unsubscribe_sub_id_not_exists(mock_pubsub_subscriptions):
+    """
+    Test Case: Unsubscribe with a PubSub.unsubscribe() method when
+    subscription ID does not exist in subscriptions dictionary.
+
+    Expected Result:
+        PubSub._subscriptions dict should have one entry. This entry's
+        key should be equal 1.
+        Return value should be False.
+    """
+    # In case of subscription id does not exist
+    result = await mock_pubsub_subscriptions.unsubscribe(sub_id=2)
+    assert len(mock_pubsub_subscriptions._subscriptions) == 1
+    assert 1 in mock_pubsub_subscriptions._subscriptions
+    assert result is False


### PR DESCRIPTION
Fixes https://github.com/kernelci/kernelci-api/issues/91

test/test_pubsub.py: Add test_unsubscribe_sub_id_not_exists test case
test/test_pubsub.py: Add test_unsubscribe_sub_id_exists test case
test/test_pubsub.py: Add mock_pubsub_subscriptions fixture
