### PR TITLE
Fix test assertions in test_api.py

### DIFF
--- a/api/test_api.py
+++ b/api/test_api.py
@@ -316,8 +316,8 @@ def test_create_node_endpoint(mock_get_current_user, mock_init_sub_id,
             )
         print("response.json()", response.json())
         assert response.status_code == 200
-        assert ('_id' and 'kind' and 'name' and
-                'revision' and 'parent' and 'status') in response.json()
+        assert ('_id', 'kind', 'name', 'revision', 'parent',
+                'status') == tuple(response.json().keys())
 
 
 @pytest.fixture()

--- a/api/test_api.py
+++ b/api/test_api.py
@@ -470,8 +470,8 @@ def test_get_node_by_id_endpoint(mock_get_current_user, mock_db_find_by_id,
         response = client.get("/node/61bda8f2eb1a63d2b7152418")
         print("response.json()", response.json())
         assert response.status_code == 200
-        assert ('_id' and 'kind' and 'name' and
-                'revision' and 'parent' and 'status') in response.json()
+        assert ('_id', 'kind', 'name', 'revision',
+                'parent', 'status') == tuple(response.json().keys())
 
 
 def test_get_node_by_id_endpoint_empty_response(mock_get_current_user,

--- a/api/test_api.py
+++ b/api/test_api.py
@@ -184,7 +184,7 @@ def test_subscribe_endpoint(mock_get_current_user, mock_init_sub_id,
         )
         print("response.json()", response.json())
         assert response.status_code == 200
-        assert ('id' and 'channel') in response.json()
+        assert ('id', 'channel') == tuple(response.json().keys())
 
 
 def test_unsubscribe_endpoint(mock_get_current_user,

--- a/api/test_api.py
+++ b/api/test_api.py
@@ -60,7 +60,7 @@ def test_token_endpoint(mock_db_find_one):
     )
     print("json", response.json())
     assert response.status_code == 200
-    assert 'access_token' and 'token_type' in response.json()
+    assert ('access_token', 'token_type') == tuple(response.json().keys())
 
 
 @pytest.fixture()

--- a/api/test_api.py
+++ b/api/test_api.py
@@ -96,8 +96,8 @@ def test_me_endpoint(mock_get_current_user):
         },
     )
     assert response.status_code == 200
-    assert ('_id' and 'username' and 'hashed_password' and
-            'active') in response.json()
+    assert ('_id', 'username', 'hashed_password', 'active') == tuple(
+                                                        response.json().keys())
 
 
 def test_token_endpoint_incorrect_password(mock_db_find_one):


### PR DESCRIPTION
Fixes https://github.com/kernelci/kernelci-api/issues/92

api/test_api.py: fix assertion in test_get_node_by_id_endpoint
api/test_api.py: fix assertion in test_token_endpoint
api/test_api.py: fix assertion in test_create_node_endpoint
api/test_api.py: fix assertion in test_subscribe_endpoint
api/test_api.py: fix assertion in test_me_endpoint