### PR TITLE
api/pubsub.py: use 'await' with aioredis unsubscribe() call

### DIFF
--- a/api/pubsub.py
+++ b/api/pubsub.py
@@ -49,7 +49,7 @@ class PubSub:
             sub = self._subscriptions.get(sub_id)
             if sub:
                 self._subscriptions.pop(sub_id)
-                sub.unsubscribe()
+                await sub.unsubscribe()
                 return True
             return False
 


### PR DESCRIPTION
Fix warning:
api/pubsub.py:52: RuntimeWarning: coroutine 'PubSub.execute_command'
was never awaited :sub.unsubscribe()

Signed-off-by: Jeny Sadadia <jeny.sadadia@gmail.com>