### PR TITLE
api/models.py: modify Revision.describe to be Optional

### DIFF
--- a/api/models.py
+++ b/api/models.py
@@ -65,7 +65,7 @@ class Revision(BaseModel):
     url: str
     branch: str
     commit: str
-    describe: str
+    describe: Optional[str] = None
 
 
 class Node(ModelId):


### PR DESCRIPTION
trigger script from the kernelci-pipeline will post
a new node with an empty Revision.describe property.
When a new revision is available, the client will
update the revision information with the git describe.

Fixes: 15380ac ("api.models: add Revision.url and .describe")
Signed-off-by: Jeny Sadadia <jeny.sadadia@gmail.com>