### PR TITLE
Add created and updated times to the Node model

### DIFF
--- a/api/db.py
+++ b/api/db.py
@@ -93,6 +93,9 @@ class Database:
         if obj.id is None:
             raise ValueError("Cannot update object with no id")
         col = self._get_collection(obj.__class__)
+        db_obj = await col.find_one({'_id': ObjectId(obj.id)})
+        if db_obj:
+            Node.set_created(obj, db_obj.get('created'))
         res = await col.replace_one(
             {'_id': ObjectId(obj.id)}, obj.dict(by_alias=True)
         )

--- a/api/db.py
+++ b/api/db.py
@@ -82,7 +82,7 @@ class Database:
         obj.id = res.inserted_id
         return obj
 
-    async def update(self, obj):
+    async def update(self, model, obj):
         """Update an existing document from a model object
 
         For a given object instance from .models, update the document in the
@@ -94,7 +94,7 @@ class Database:
             raise ValueError("Cannot update object with no id")
         col = self._get_collection(obj.__class__)
         db_obj = await col.find_one({'_id': ObjectId(obj.id)})
-        if db_obj:
+        if db_obj and model == Node:
             Node.set_created(obj, db_obj.get('created'))
         res = await col.replace_one(
             {'_id': ObjectId(obj.id)}, obj.dict(by_alias=True)

--- a/api/main.py
+++ b/api/main.py
@@ -108,7 +108,7 @@ async def post_node(node: Node, token: str = Depends(get_user)):
 async def put_node(node_id: str, node: Node, token: str = Depends(get_user)):
     try:
         node.id = ObjectId(node_id)
-        obj = await db.update(node)
+        obj = await db.update(Node, node)
         op = 'updated'
     except ValueError as e:
         raise HTTPException(

--- a/api/models.py
+++ b/api/models.py
@@ -6,7 +6,7 @@
 """KernelCI API model definitions"""
 
 from typing import Optional
-
+from datetime import datetime
 from bson import ObjectId
 from pydantic import BaseModel, Field
 
@@ -75,3 +75,5 @@ class Node(ModelId):
     revision: Revision
     parent: Optional[PyObjectId]
     status: Optional[bool] = None
+    created: Optional[datetime] = Field(default_factory=datetime.utcnow)
+    updated: Optional[datetime] = Field(default_factory=datetime.utcnow)

--- a/api/models.py
+++ b/api/models.py
@@ -77,3 +77,8 @@ class Node(ModelId):
     status: Optional[bool] = None
     created: Optional[datetime] = Field(default_factory=datetime.utcnow)
     updated: Optional[datetime] = Field(default_factory=datetime.utcnow)
+
+    @classmethod
+    def set_created(cls, obj, value):
+        """Set the value of 'created' Node attribute"""
+        setattr(obj, 'created', value)

--- a/test/test_node_handler.py
+++ b/test/test_node_handler.py
@@ -116,8 +116,8 @@ def test_create_node_endpoint(mock_get_current_user, mock_init_sub_id,
             )
         print("response.json()", response.json())
         assert response.status_code == 200
-        assert ('_id', 'kind', 'name', 'revision', 'parent',
-                'status') == tuple(response.json().keys())
+        assert ('_id', 'kind', 'name', 'revision', 'parent', 'status',
+                'created', 'updated') == tuple(response.json().keys())
 
 
 def test_get_node_by_attributes_endpoint(mock_get_current_user,
@@ -254,8 +254,8 @@ def test_get_node_by_id_endpoint(mock_get_current_user, mock_db_find_by_id,
         response = client.get("/node/61bda8f2eb1a63d2b7152418")
         print("response.json()", response.json())
         assert response.status_code == 200
-        assert ('_id', 'kind', 'name', 'revision',
-                'parent', 'status') == tuple(response.json().keys())
+        assert ('_id', 'kind', 'name', 'revision', 'parent', 'status',
+                'created', 'updated') == tuple(response.json().keys())
 
 
 def test_get_node_by_id_endpoint_empty_response(mock_get_current_user,


### PR DESCRIPTION
Fixes https://github.com/kernelci/kernelci-api/issues/38

api/models.py: add 'created' and 'updated' fields to Node
test/test_node_handler.py: add timestamp fields in response json
Store created and updated timestamp for Node

Signed-off-by: Jeny Sadadia <jeny.sadadia@gmail.com>