### PR TITLE
Pubsub event filter

### DIFF
--- a/api/client.py
+++ b/api/client.py
@@ -2,6 +2,7 @@ import argparse
 import os
 import requests
 import urllib.parse
+import json
 
 from cloudevents.http import CloudEvent, to_structured, from_json
 
@@ -31,7 +32,10 @@ def listen(args):
     }
     path = '/'.join(['subscribe', args.channel])
     url = urllib.parse.urljoin(args.url, path)
-    res = requests.post(url, headers=headers)
+    res = requests.post(url, headers=headers,
+                        data=json.dumps({"name": "checkout",
+                                        "revision": {"tree": "'mainline'",
+                                                     "branch": "'master'"}}))
     res.raise_for_status()
 
     print(f"Listening for events on channel {args.channel}.")

--- a/api/main.py
+++ b/api/main.py
@@ -100,7 +100,11 @@ async def post_node(node: Node, token: str = Depends(get_user)):
             status_code=status.HTTP_400_BAD_REQUEST,
             detail=str(e)
         )
-    await pubsub.publish_cloudevent('node', {'op': op, 'id': str(obj.id)})
+    await pubsub.publish_cloudevent('node', {
+                                    'op': op, 'id': str(obj.id),
+                                    'name': str(obj.name),
+                                    'revision': str(obj.revision)}
+                                    )
     return obj
 
 
@@ -115,7 +119,11 @@ async def put_node(node_id: str, node: Node, token: str = Depends(get_user)):
             status_code=status.HTTP_400_BAD_REQUEST,
             detail=str(e)
         )
-    await pubsub.publish_cloudevent('node', {'op': op, 'id': str(obj.id)})
+    await pubsub.publish_cloudevent('node', {
+                                    'op': op, 'id': str(obj.id),
+                                    'name': str(obj.name),
+                                    'revision': str(obj.revision)}
+                                    )
     return obj
 
 

--- a/api/main.py
+++ b/api/main.py
@@ -9,7 +9,7 @@ from .auth import Authentication, Token
 from .db import Database
 from .models import Node, User
 from .pubsub import PubSub, Subscription
-from typing import List
+from typing import List, Optional
 from bson import ObjectId
 
 app = FastAPI()
@@ -123,8 +123,9 @@ async def put_node(node_id: str, node: Node, token: str = Depends(get_user)):
 # Pub/Sub
 
 @app.post('/subscribe/{channel}', response_model=Subscription)
-async def subscribe(channel: str, user: User = Depends(get_user)):
-    return await pubsub.subscribe(channel)
+async def subscribe(channel: str, filters: Optional[dict] = None,
+                    user: User = Depends(get_user)):
+    return await pubsub.subscribe(channel, filters)
 
 
 @app.post('/unsubscribe/{sub_id}')

--- a/api/pubsub.py
+++ b/api/pubsub.py
@@ -24,7 +24,7 @@ class Subscription(BaseModel):
     """Pub/Sub subscription object model"""
     id: int
     channel: str
-    filter: Optional[dict] = None
+    filters: Optional[dict] = None
 
 
 class PubSub:
@@ -59,7 +59,7 @@ class PubSub:
     async def _init_sub_id(self):
         await self._redis.setnx(self.ID_KEY, 0)
 
-    async def subscribe(self, channel, filter=None):
+    async def subscribe(self, channel, filters=None):
         """Subscribe to a Pub/Sub channel
 
         Subscribe to a given channel and return a Subscription object
@@ -70,9 +70,9 @@ class PubSub:
         async with self._lock:
             sub = self._redis.pubsub()
             self._subscriptions[sub_id] = sub
-            self._filters[sub_id] = filter
+            self._filters[sub_id] = filters
             await sub.subscribe(channel)
-            return Subscription(id=sub_id, channel=channel, filter=filter)
+            return Subscription(id=sub_id, channel=channel, filters=filters)
 
     async def unsubscribe(self, sub_id):
         """Unsubscribe from a Pub/Sub channel

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -134,6 +134,8 @@ def mock_pubsub_subscriptions(mocker):
     mocker.patch.object(pubsub, '_redis', redis_mock)
     subscriptions_mock = dict({1: pubsub._redis.pubsub()})
     mocker.patch.object(pubsub, '_subscriptions', subscriptions_mock)
+    filters_mock = dict({1: None})
+    mocker.patch.object(pubsub, '_filters', filters_mock)
     return pubsub
 
 

--- a/test/test_pubsub.py
+++ b/test/test_pubsub.py
@@ -17,15 +17,18 @@ async def test_subscribe_single_channel(mock_pubsub):
 
     Expected Result:
         Subscription-like object is returned from PubSub.subscribe() method
-        with channel set to 'CHANNEL' and id set to 1.
-        PubSub._subscriptions dict should have one entry. This entry's
-        key should be equal 1.
+        with channel set to 'CHANNEL', id set to 1, and filters set to None.
+        PubSub._subscriptions and PubSub._filters dict should have one entry.
+        This entry's key should be equal 1.
     """
     result = await mock_pubsub.subscribe('CHANNEL')
     assert result.channel == 'CHANNEL'
     assert result.id == 1
+    assert result.filters is None
     assert len(mock_pubsub._subscriptions) == 1
     assert 1 in mock_pubsub._subscriptions
+    assert len(mock_pubsub._filters) == 1
+    assert 1 in mock_pubsub._filters
 
 
 @pytest.mark.asyncio
@@ -39,16 +42,19 @@ async def test_subscribe_multiple_channels(mock_pubsub):
         PubSub.subscribe() method
         Subsequent calls should have channel names: 'CHANNEL1', 'CHANNEL2',
         'CHANNEL3' and should have ids 1, 2, 3 respectively.
-        PubSub._subscriptions dict should have 2 entries. This entries'
-        keys should be 1, 2, and 3.
+        PubSub._subscriptions and PubSub._filters dict should have 3 entries.
+        This entries' keys should be 1, 2, and 3.
     """
     channels = ((1, 'CHANNEL1'), (2, 'CHANNEL2'), (3, 'CHANNEL3'))
     for expected_id, expected_channel in channels:
         result = await mock_pubsub.subscribe(expected_channel)
         assert result.channel == expected_channel
         assert result.id == expected_id
+        assert result.filters is None
     assert len(mock_pubsub._subscriptions) == 3
+    assert len(mock_pubsub._filters) == 3
     assert (1, 2, 3) == tuple(mock_pubsub._subscriptions.keys())
+    assert (1, 2, 3) == tuple(mock_pubsub._filters.keys())
 
 
 @pytest.mark.asyncio

--- a/test/test_pubsub.py
+++ b/test/test_pubsub.py
@@ -58,11 +58,12 @@ async def test_unsubscribe_sub_id_exists(mock_pubsub_subscriptions):
     subscription ID exists in subscriptions dictionary.
 
     Expected Result:
-        PubSub._subscriptions dict should be empty.
+        PubSub._subscriptions and PubSub._filters dict should be empty.
     """
     # In case of subscription id exists
     await mock_pubsub_subscriptions.unsubscribe(sub_id=1)
     assert len(mock_pubsub_subscriptions._subscriptions) == 0
+    assert len(mock_pubsub_subscriptions._filters) == 0
 
 
 @pytest.mark.asyncio
@@ -72,11 +73,13 @@ async def test_unsubscribe_sub_id_not_exists(mock_pubsub_subscriptions):
     subscription ID does not exist in subscriptions dictionary.
 
     Expected Result:
-        PubSub._subscriptions dict should have one entry. This entry's
-        key should be equal 1.
+        PubSub._subscriptions and PubSub._filters dict should have one entry.
+        These entry's key should be equal 1.
     """
     # In case of subscription id does not exist
     with pytest.raises(ValueError):
         await mock_pubsub_subscriptions.unsubscribe(sub_id=2)
     assert len(mock_pubsub_subscriptions._subscriptions) == 1
     assert 1 in mock_pubsub_subscriptions._subscriptions
+    assert len(mock_pubsub_subscriptions._filters) == 1
+    assert 1 in mock_pubsub_subscriptions._filters

--- a/test/test_subscribe_handler.py
+++ b/test/test_subscribe_handler.py
@@ -21,9 +21,9 @@ def test_subscribe_endpoint(mock_get_current_user, mock_init_sub_id,
     Test Case : Test KernelCI API /subscribe endpoint
     Expected Result :
         HTTP Response Code 200 OK
-        JSON with 'id' and 'channel' keys
+        JSON with 'id', 'channel', and 'filters' keys
     """
-    subscribe = Subscription(id=1, channel='abc')
+    subscribe = Subscription(id=1, channel='abc', filters=None)
     mock_subscribe.return_value = subscribe
 
     with TestClient(app) as client:
@@ -36,4 +36,4 @@ def test_subscribe_endpoint(mock_get_current_user, mock_init_sub_id,
         )
         print("response.json()", response.json())
         assert response.status_code == 200
-        assert ('id', 'channel') == tuple(response.json().keys())
+        assert ('id', 'channel', 'filters') == tuple(response.json().keys())


### PR DESCRIPTION
Fixes https://github.com/kernelci/kernelci-api/issues/28

api.pubsub: add class members for pubsub event filters
api.pubsub: filter pubsub events in listen method
api/main.py: add filter in subscribe
api/main.py: add data fields to 'create' and 'update' events
test/test_pubsub: add _filters to unsubscribe test cases 
test/test_pubsub: add _filters to subscribe test cases
test/test_subscribe_handler: add 'filter' to subscribe test case
api/client: add filter dict to subscribe post data