### PR TITLE
Pub/Sub: raise exceptions when invalid id

### DIFF
--- a/api/main.py
+++ b/api/main.py
@@ -129,23 +129,24 @@ async def subscribe(channel: str, user: User = Depends(get_user)):
 
 @app.post('/unsubscribe/{sub_id}')
 async def unsubscribe(sub_id: int, user: User = Depends(get_user)):
-    res = await pubsub.unsubscribe(sub_id)
-    if res is False:
+    try:
+        await pubsub.unsubscribe(sub_id)
+    except ValueError as error:
         raise HTTPException(
-            status_code=status.HTTP_204_NO_CONTENT,
-            detail=f"Already unsubscribed: {sub_id}"
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=str(error)
         )
 
 
 @app.get('/listen/{sub_id}')
 async def listen(sub_id: int, user: User = Depends(get_user)):
-    msg = await pubsub.listen(sub_id)
-    if msg is None:
+    try:
+        return await pubsub.listen(sub_id)
+    except ValueError as error:
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,
-            detail=f"Not subscribed to channel with id: {sub_id}"
+            detail=str(error)
         )
-    return msg
 
 
 @app.post('/publish/{channel}')

--- a/api/pubsub.py
+++ b/api/pubsub.py
@@ -74,26 +74,27 @@ class PubSub:
         """Unsubscribe from a Pub/Sub channel
 
         Unsubscribe from a channel using the provided subscription id as found
-        in a Subscription object.
+        in a Subscription object.  Raise a ValueError if the id is not a valid
+        one.
         """
         async with self._lock:
             sub = self._subscriptions.get(sub_id)
-            if sub:
-                self._subscriptions.pop(sub_id)
-                await sub.unsubscribe()
-                return True
-            return False
+            if sub is None:
+                raise ValueError(f"Invalid subscription id: {sub_id}")
+            self._subscriptions.pop(sub_id)
+            await sub.unsubscribe()
 
     async def listen(self, sub_id):
         """Listen for Pub/Sub messages
 
         Listen on a given subscription id asynchronously and return a message
         when received.  Messages about subscribing to the channel are silenced.
+        Raise a ValueError if the id is not a valid one.
         """
         async with self._lock:
             sub = self._subscriptions.get(sub_id)
-            if not sub:
-                return None
+            if sub is None:
+                raise ValueError(f"Invalid subscription id: {sub_id}")
 
         while True:
             msg = await sub.get_message(

--- a/test/test_listen_handler.py
+++ b/test/test_listen_handler.py
@@ -53,11 +53,11 @@ def test_listen_endpoint(mock_get_current_user,
                 active=True)
     mock_get_current_user.return_value = user
     mock_listen.return_value = 'Listening for events on channel 1'
+
     with TestClient(app) as client:
         response = client.get(
             "/listen/1",
             headers={
-                "Accept": "application/json",
                 "Authorization": "Bearer "
                 "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9."
                 "eyJzdWIiOiJib2IifQ.ci1smeJeuX779PptTkuaG1S"
@@ -68,22 +68,25 @@ def test_listen_endpoint(mock_get_current_user,
 
 
 def test_listen_endpoint_not_found(mock_get_current_user,
-                                   mock_init_sub_id,
-                                   mock_listen):
+                                   mock_init_sub_id):
     """
     Test Case : Test KernelCI API GET /listen endpoint for the
     negative path
     Expected Result :
         HTTP Response Code 404 Not Found
-        Channel not available or not subscribed to channel with an id
+        JSON with 'detail' key
+        No existing pub/sub subscription with provided id
     """
-    mock_listen.return_value = None
+    user = User(username='bob',
+                hashed_password='$2b$12$CpJZx5ooxM11bCFXT76/z.o6HWs2sPJy4iP8.'
+                                'xCZGmM8jWXUXJZ4K',
+                active=True)
+    mock_get_current_user.return_value = user
 
     with TestClient(app) as client:
         response = client.get(
             "/listen/1",
             headers={
-                "Accept": "application/json",
                 "Authorization": "Bearer "
                 "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9."
                 "eyJzdWIiOiJib2IifQ.ci1smeJeuX779PptTkuaG1S"
@@ -91,11 +94,11 @@ def test_listen_endpoint_not_found(mock_get_current_user,
             },
         )
         assert response.status_code == 404
+        assert 'detail' in response.json()
 
 
 def test_listen_endpoint_without_token(mock_get_current_user,
-                                       mock_init_sub_id,
-                                       mock_listen):
+                                       mock_init_sub_id):
     """
     Test Case : Test KernelCI API GET /listen endpoint for the
     negative path
@@ -108,7 +111,7 @@ def test_listen_endpoint_without_token(mock_get_current_user,
                                 'xCZGmM8jWXUXJZ4K',
                 active=True)
     mock_get_current_user.return_value = user
-    mock_listen.return_value = 'Listening for events on channel 1'
+
     with TestClient(app) as client:
         response = client.get(
             "/listen/1",

--- a/test/test_pubsub.py
+++ b/test/test_pubsub.py
@@ -75,12 +75,10 @@ async def test_unsubscribe_sub_id_exists(mock_pubsub_subscriptions):
 
     Expected Result:
         PubSub._subscriptions dict should be empty.
-        Return value should be True.
     """
     # In case of subscription id exists
-    result = await mock_pubsub_subscriptions.unsubscribe(sub_id=1)
+    await mock_pubsub_subscriptions.unsubscribe(sub_id=1)
     assert len(mock_pubsub_subscriptions._subscriptions) == 0
-    assert result is True
 
 
 @pytest.mark.asyncio
@@ -92,10 +90,9 @@ async def test_unsubscribe_sub_id_not_exists(mock_pubsub_subscriptions):
     Expected Result:
         PubSub._subscriptions dict should have one entry. This entry's
         key should be equal 1.
-        Return value should be False.
     """
     # In case of subscription id does not exist
-    result = await mock_pubsub_subscriptions.unsubscribe(sub_id=2)
+    with pytest.raises(ValueError):
+        await mock_pubsub_subscriptions.unsubscribe(sub_id=2)
     assert len(mock_pubsub_subscriptions._subscriptions) == 1
     assert 1 in mock_pubsub_subscriptions._subscriptions
-    assert result is False

--- a/test/test_unsubscribe_handler.py
+++ b/test/test_unsubscribe_handler.py
@@ -46,7 +46,6 @@ def test_unsubscribe_endpoint(mock_get_current_user,
                                 'xCZGmM8jWXUXJZ4K',
                 active=True)
     mock_get_current_user.return_value = user
-    mock_unsubscribe.return_value = True
 
     with TestClient(app) as client:
         response = client.post(
@@ -66,7 +65,7 @@ def test_unsubscribe_endpoint_empty_response(mock_get_current_user,
     """
     Test Case : Test KernelCI API /unsubscribe endpoint negative path
     Expected Result :
-        HTTP Response Code 204 HTTP_204_NO_CONTENT
+        HTTP Response Code 404 Not Found
         JSON with 'detail' key
     """
     user = User(username='bob',
@@ -86,5 +85,5 @@ def test_unsubscribe_endpoint_empty_response(mock_get_current_user,
             },
         )
         print("response.json()", response.json())
-        assert response.status_code == 204
+        assert response.status_code == 404
         assert 'detail' in response.json()


### PR DESCRIPTION
Raise a `ValueError` exception when the subscription id is not valid.