### PR TITLE
api.models.Node: add artifacts

### DIFF
--- a/api/models.py
+++ b/api/models.py
@@ -5,7 +5,7 @@
 
 """KernelCI API model definitions"""
 
-from typing import Optional
+from typing import Optional, Dict
 
 from bson import ObjectId
 from pydantic import BaseModel, Field
@@ -75,3 +75,4 @@ class Node(ModelId):
     revision: Revision
     parent: Optional[PyObjectId]
     status: Optional[bool] = None
+    artifacts: Optional[Dict]

--- a/test/test_node_handler.py
+++ b/test/test_node_handler.py
@@ -116,8 +116,15 @@ def test_create_node_endpoint(mock_get_current_user, mock_init_sub_id,
             )
         print("response.json()", response.json())
         assert response.status_code == 200
-        assert ('_id', 'kind', 'name', 'revision', 'parent',
-                'status') == tuple(response.json().keys())
+        assert response.json().keys() == {
+            '_id',
+            'artifacts',
+            'kind',
+            'name',
+            'parent',
+            'revision',
+            'status',
+        }
 
 
 def test_get_node_by_attributes_endpoint(mock_get_current_user,
@@ -254,8 +261,15 @@ def test_get_node_by_id_endpoint(mock_get_current_user, mock_db_find_by_id,
         response = client.get("/node/61bda8f2eb1a63d2b7152418")
         print("response.json()", response.json())
         assert response.status_code == 200
-        assert ('_id', 'kind', 'name', 'revision',
-                'parent', 'status') == tuple(response.json().keys())
+        assert response.json().keys() == {
+            '_id',
+            'artifacts',
+            'kind',
+            'name',
+            'parent',
+            'revision',
+            'status',
+        }
 
 
 def test_get_node_by_id_endpoint_empty_response(mock_get_current_user,


### PR DESCRIPTION
Add optional artifacts dictionary to the Node model as a mapping
between names and URLs to download files from the storage.

Signed-off-by: Guillaume Tucker <guillaume.tucker@collabora.com>