### PR TITLE
docker-compose.yaml: bind-mount volume with tests

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -14,6 +14,7 @@ services:
         - REQUIREMENTS=${REQUIREMENTS:-requirements.txt}
     volumes:
       - './api:/home/kernelci/api'
+      - './test:/home/kernelci/test'
     ports:
       - '${API_HOST_PORT:-8001}:8000'
     env_file:


### PR DESCRIPTION
Add a bind-mount volume with the 'test' directory to the api container
so unit tests can be run in the same environment.  To run the unit
tests by hand, one can now do:

  $ REQUIREMENTS=requirements-dev.txt docker-compose build
  $ docker-compose run api pytest test

Signed-off-by: Guillaume Tucker <guillaume.tucker@collabora.com>