### PR TITLE
gitignore: add ssh and storage data directories

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@ __pycache__
 .env
 docker/db/data
 docker/redis/data
+docker/ssh/user-data
+docker/storage/data


### PR DESCRIPTION
Add the ssh user-data and storage data directories to .gitignore as
they contain data files which should not be kept under source control.

Signed-off-by: Guillaume Tucker <guillaume.tucker@collabora.com>