### PR TITLE
Convert `/hash` to `POST`

### DIFF
--- a/api/main.py
+++ b/api/main.py
@@ -7,7 +7,7 @@ from fastapi import Depends, FastAPI, HTTPException, status, Request
 from fastapi.security import OAuth2PasswordBearer, OAuth2PasswordRequestForm
 from .auth import Authentication, Token
 from .db import Database
-from .models import Node, User
+from .models import Node, User, Password
 from .pubsub import PubSub, Subscription
 from typing import List
 from bson import ObjectId, errors
@@ -72,9 +72,9 @@ async def read_users_me(current_user: User = Depends(get_user)):
     return current_user
 
 
-@app.get('/hash/{password}')
-def get_password_hash(password):
-    return auth.get_password_hash(password)
+@app.post('/hash')
+def get_password_hash(password: Password):
+    return auth.get_password_hash(password.password)
 
 
 # -----------------------------------------------------------------------------

--- a/api/models.py
+++ b/api/models.py
@@ -58,6 +58,15 @@ class ModelId(BaseModel):
         }
 
 
+class Password(BaseModel):
+    """Basic model to be able to send plaintext passwords
+
+    This model is required to be able to send a plaintext password in a POST
+    method in order to retrieve a hash.
+    """
+    password: str
+
+
 # -----------------------------------------------------------------------------
 # Database models
 #

--- a/doc/getting-started.md
+++ b/doc/getting-started.md
@@ -71,16 +71,24 @@ kernelci-api | INFO:     172.20.0.1:49228 - "GET / HTTP/1.1" 200 OK
 
 Some parts of the API don't require any authentication, like in the example
 above with the root `/` endpoint and most `GET` requests to retrieve data.
-However, sending data with `POST` and `PUT` requests will require a user token.
-This will be required to run a full pipeline or to subscribe to the pub/sub
-interface.  At the moment, there is no web UI for creating new user accounts or
-obtaining API tokens so it needs to be done manually.
+However, sending data with `POST` and `PUT` requests can typically only be done
+by authenticated users.  This will be required to run a full pipeline or to
+subscribe to the pub/sub interface.  At the moment, there is no web UI for
+creating new user accounts or obtaining API tokens so it needs to be done
+manually.
 
-First, get an encrypted hash for the password you want to use using the `/hash`
-API endpoint.  For example, if the password is `hello`:
+First, get an encrypted hash for your password with the `/hash` API endpoint.
+This uses a `POST` method to avoid putting the plaintext password in the URL
+which could be leaked in server logs, but it doesn't require authentication
+since it's needed to create an initial user account.  For example, if the
+password is `hello`:
 
 ```
-$ curl http://localhost:8001/hash/hello
+curl \
+  -X POST \
+  -H 'Content-Type: application/json' \
+  -d '{"password": "hello"}' \
+  http://localhost:8001/hash
 "$2b$12$CpJZx5ooxM11bCFXT76/z.o6HWs2sPJy4iP8.xCZGmM8jWXUXJZ4K"
 ```
 


### PR DESCRIPTION
Convert the `/hash` endpoint to use `POST` method so the plaintext passwords aren't sent as part of the URL.