### PR TITLE
T35357 Implement unit tests for  /user endpoint

### DIFF
--- a/test/conftest.py
+++ b/test/conftest.py
@@ -2,6 +2,9 @@
 #
 # Copyright (C) 2022 Jeny Sadadia
 # Author: Jeny Sadadia <jeny.sadadia@gmail.com>
+#
+# Copyright (C) 2022 Collabora Limited
+# Author: Jeny Sadadia <jeny.sadadia@collabora.com>
 
 # pylint: disable=protected-access
 
@@ -17,9 +20,13 @@ from api.models import User
 from api.pubsub import PubSub
 
 BEARER_TOKEN = "Bearer \
-            eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9. \
-            eyJzdWIiOiJib2IifQ.ci1smeJeuX779PptTkuaG1S \
-            Edkp5M1S1AgYvX8VdB20"
+eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJib2IifQ.\
+ci1smeJeuX779PptTkuaG1SEdkp5M1S1AgYvX8VdB20"
+
+ADMIN_BEARER_TOKEN = 'Bearer \
+eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.\
+eyJzdWIiOiJib2IiLCJzY29wZXMiOlsiYWRtaW4iXX0.\
+t3bAE-pHSzZaSHp7FMlImqgYvL6f_0xDUD-nQwxEm3k'
 
 
 @pytest.fixture
@@ -81,6 +88,23 @@ def mock_get_current_user(mocker):
                 hashed_password='$2b$12$CpJZx5ooxM11bCFXT76/z.o6HWs2sPJy4iP8.'
                                 'xCZGmM8jWXUXJZ4K',
                 active=True, is_admin=False)
+    mocker.patch('api.auth.Authentication.get_current_user',
+                 side_effect=async_mock)
+    async_mock.return_value = user, None
+    return async_mock
+
+
+@pytest.fixture
+def mock_get_current_admin_user(mocker):
+    """
+    Mocks async call to Authentication class method
+    used to get current user
+    """
+    async_mock = AsyncMock()
+    user = User(username='admin',
+                hashed_password='$2b$12$CpJZx5ooxM11bCFXT76/z.o6HWs2sPJy4iP8.'
+                                'xCZGmM8jWXUXJZ4K',
+                active=True, is_admin=True)
     mocker.patch('api.auth.Authentication.get_current_user',
                  side_effect=async_mock)
     async_mock.return_value = user, None

--- a/test/test_user_handler.py
+++ b/test/test_user_handler.py
@@ -1,0 +1,100 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+#
+# Copyright (C) 2022 Collabora Limited
+# Author: Jeny Sadadia <jeny.sadadia@collabora.com>
+
+# pylint: disable=unused-argument
+
+"""Unit test function for KernelCI API user handler"""
+
+import json
+
+from test.conftest import ADMIN_BEARER_TOKEN, BEARER_TOKEN
+
+from fastapi.testclient import TestClient
+
+from api.main import app
+from api.models import User
+
+
+def test_create_regular_user(mock_init_sub_id, mock_get_current_admin_user,
+                             mock_db_create, mock_publish_cloudevent):
+    """
+    Test Case : Test KernelCI API /user endpoint to create regular user
+    when requested with admin user's bearer token
+    Expected Result :
+        HTTP Response Code 200 OK
+        JSON with '_id', 'username', 'hashed_password'
+        'active', and 'is_admin' keys
+    """
+    user = User(username='test', hashed_password="$2b$12$Whi.dpTC.\
+HR5UHMdMFQeOe1eD4oXaP08oW7ogYqyiNziZYNdUHs8i", active=True)
+    mock_db_create.return_value = user
+
+    with TestClient(app) as client:
+        response = client.post(
+            "/user/test",
+            headers={
+                "Accept": "application/json",
+                "Authorization": ADMIN_BEARER_TOKEN
+            },
+            data=json.dumps({"password": "test"})
+        )
+        print(response.json())
+        assert response.status_code == 200
+        assert ('_id', 'username', 'hashed_password', 'active',
+                'is_admin') == tuple(response.json().keys())
+
+
+def test_create_admin_user(mock_init_sub_id, mock_get_current_admin_user,
+                           mock_db_create, mock_publish_cloudevent):
+    """
+    Test Case : Test KernelCI API /user endpoint to create admin user
+    when requested with admin user's bearer token
+    Expected Result :
+        HTTP Response Code 200 OK
+        JSON with '_id', 'username', 'hashed_password'
+        'active', and 'is_admin' keys
+    """
+    user = User(username='test_admin', hashed_password="$2b$12$Whi.dpTC.\
+HR5UHMdMFQeOe1eD4oXaP08oW7ogYqyiNziZYNdUHs8i", active=True, is_admin=True)
+    mock_db_create.return_value = user
+
+    with TestClient(app) as client:
+        response = client.post(
+            "/user/test_admin?is_admin=1",
+            headers={
+                "Accept": "application/json",
+                "Authorization": ADMIN_BEARER_TOKEN
+            },
+            data=json.dumps({"password": "test"})
+        )
+        print(response.json())
+        assert response.status_code == 200
+        assert ('_id', 'username', 'hashed_password', 'active',
+                'is_admin') == tuple(response.json().keys())
+
+
+def test_create_user_endpoint_negative(mock_init_sub_id, mock_get_current_user,
+                                       mock_publish_cloudevent):
+    """
+    Test Case : Test KernelCI API /user endpoint when requested
+    with regular user's bearer token
+    Expected Result :
+        HTTP Response Code 401 Unauthorized
+        JSON with 'detail' key denoting 'Access denied' error
+    """
+    mock_get_current_user.return_value = None, "Access denied"
+
+    with TestClient(app) as client:
+        response = client.post(
+            "/user/test",
+            headers={
+                "Accept": "application/json",
+                "Authorization": BEARER_TOKEN
+            },
+            data=json.dumps({"password": "test"})
+        )
+        print(response.json())
+        assert response.status_code == 401
+        assert response.json() == {'detail': 'Access denied'}


### PR DESCRIPTION
Depends on https://github.com/kernelci/kernelci-api/pull/140

Develop tests for /user endpoint for the positive and negative paths.