### PR TITLE
T35622 API: Add documentation for admin user

### DIFF
--- a/doc/api-details.md
+++ b/doc/api-details.md
@@ -39,6 +39,24 @@ MongoDB server version: 5.0.8
 WriteResult({ "nInserted" : 1 })
 ```
 
+### Create an API token with security scopes
+
+We can associate available security scopes with an API token. Currently available scopes are 'admin' (admin user permissions) and 'users' (regular user permissions).
+
+To get a token with desired user scope, provide `scope` to request data dictionary along with the username and password.
+Multiple scopes can be provided with white space separation. For example:
+
+```
+$ curl -X 'POST' \
+  'http://localhost:8001/token' \
+  -H 'accept: application/json' \
+  -H 'Content-Type: application/x-www-form-urlencoded' \
+  s-d 'grant_type=&username=test_admin&password=admin&scope=admin users'
+{'access_token': 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJ0ZXN0X2FkbWluIiwic2NvcGVzIjpbImFkbWluIl19.NWShAwOodFl2iCcDh0YB8O4xzfaRlIS4GkzUO8OQhQg', 'token_type': 'bearer'}
+```
+
+> **Note** Only admin users can provide `admin` scope to the `/token` endpoint.
+
 
 ## Nodes
 

--- a/doc/api-details.md
+++ b/doc/api-details.md
@@ -57,6 +57,32 @@ $ curl -X 'POST' \
 
 > **Note** Only admin users can provide `admin` scope to the `/token` endpoint.
 
+### Create user using endpoint
+
+Now, we can use above created admin user to create regular users and other admin users using `/user` API endpoint.
+We need to provide token (retrieved with scope admin) to the endpoint for the authorization. 
+
+To create a regular user, provide a username to request query parameter and password to request data dictionary.
+
+```
+$ curl -X 'POST' 
+  'http://localhost:8001/user/test' \
+  -H 'accept: application/json' \
+  -H 'Content-Type: application/json' \
+  -H 'Authorization: Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJ0ZXN0Iiwic2NvcGVzIjpbImFkbWluIiwidXNlciJdfQ.KhcIWfMRr3xTFSCLcr5L4KTUVSsfSsLeyRDEjgkQRBg' \
+  -d '{"password": "test"}'
+{'_id': '615f30020eb7c3c6616e5ac3', 'username': 'test', 'hashed_password': '$2b$12$Whi.dpTC.HR5UHMdMFQeOe1eD4oXaP08oW7ogYqyiNziZYNdUHs8i', 'active': True, 'is_admin': False}
+```
+
+To create an admin user, provide a username, and `is_admin` flag to request query parameter and password to request data dictionary.
+
+```
+$ curl -X 'POST' 'http://localhost:8001/user/test_admin?is_admin=1' -H 'accept: application/json'   -H 'Content-Type: application/json'  -H 'Authorization: Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJ0ZXN0Iiwic2NvcGVzIjpbImFkbWluIiwidXNlciJdfQ.KhcIWfMRr3xTFSCLcr5L4KTUVSsfSsLeyRDEjgkQRBg' -d '{"password": "admin"}'
+{'_id': '615f30020eb7c3c6616e5ac6', 'username': 'test_admin', 'hashed_password': '$2b$12$Whi.dpTC.HR5UHMdMFQeOe1eD4oXaP08oW7ogYqyiNziZYNdUHs8i', 'active': True, 'is_admin': True}
+```
+
+Another way of creating users is to use `kci_data` from kernelci-core. The instructions are described [here](https://kernelci.org/docs/core/kci_data/#creating-user).
+
 
 ## Nodes
 

--- a/doc/api-details.md
+++ b/doc/api-details.md
@@ -21,6 +21,25 @@ ACCESS_TOKEN_EXPIRE_MINUTES is set default to None.
 If a user wants to change any of the above variables, they should be added to the .env file.
 
 
+## Users
+
+`User` model objects can be created from a terminal or using `/user` endpoint.
+
+### Create an admin user
+
+The very first admin user needs to be created from terminal.
+To create an admin user from a terminal, provide `is_admin: 1` to the request:
+
+```
+sudo docker-compose exec db /bin/mongo kernelci --eval   "db.user.insert({username: 'admin', hashed_password: '\$2b\$12\$VtfVij6zz20F/Qr0Ri18O.11.0LJMMXyJxAJAHQbKU0jC96eo2fr.', active: true, is_admin: 1})"
+MongoDB shell version v5.0.8
+connecting to: mongodb://127.0.0.1:27017/kernelci?compressors=disabled&gssapiServiceName=mongodb
+Implicit session: session { "id" : UUID("03737b4c-7528-43ae-9cb8-8f345748267f") }
+MongoDB server version: 5.0.8
+WriteResult({ "nInserted" : 1 })
+```
+
+
 ## Nodes
 
 As a proof-of-concept, an object model called `Node` is defined in this API.

--- a/doc/getting-started.md
+++ b/doc/getting-started.md
@@ -141,6 +141,9 @@ $ curl -X 'GET' \
 {"_id":"615f30020eb7c3c6616e5ac3","username":"bob","hashed_password":"$2b$12$VtfVij6zz20F/Qr0Ri18O.11.0LJMMXyJxAJAHQbKU0jC96eo2fr.","active":true}
 ```
 
+The token for an admin user should be created with admin scope so that other users can be created using kernelci-core command line tools or `/user` endpoint. More details are described [here](https://kernelci.org/docs/api/api-details/#create-an-API-token-with-security-scopes).
+
+
 ## Setting up a Pipeline instance
 
 The pipeline can perform a minimal set of tests using solely the API and its

--- a/doc/getting-started.md
+++ b/doc/getting-started.md
@@ -114,6 +114,8 @@ MongoDB server version: 5.0.3
 WriteResult({ "nInserted" : 1 })
 ```
 
+Even though after creating the above user, we would be able to run API, ideally, an admin user needs to be created first (using terminal), and then additional users can be created with the `/user` endpoint or kernelci-core command line tools (`kci_data`). The instructions are described [here](https://kernelci.org/docs/api/api-details/#users).
+
 ### Create an API token
 
 Then to get an API token, the `/token` API endpoint can be used.  For example,


### PR DESCRIPTION
Add instructions for adding users using `/user` endpoint.
Also, add description for getting token for an admin user.