### PR TITLE
T35960 Fix authorization issue

### DIFF
--- a/api/main.py
+++ b/api/main.py
@@ -141,7 +141,7 @@ async def read_users_me(current_user: User = Depends(get_user)):
 @app.post('/hash')
 def get_password_hash(password: Password):
     """Get a password hash from the provided string password"""
-    return auth.get_password_hash(str(password.password))
+    return auth.get_password_hash(password.password.get_secret_value())
 
 
 # -----------------------------------------------------------------------------


### PR DESCRIPTION
Fix `CryptContext.verify` failing with the correct username and password. Need to use `get_secret_value()`
to get password in plain text while getting hash from password of type `SecretStr`.