### PR TITLE
T35078 api: drop Node.set_timeout_status, trigger_completed_event handler

### DIFF
--- a/api/main.py
+++ b/api/main.py
@@ -8,10 +8,8 @@
 
 """KernelCI API main module"""
 
-from datetime import timedelta
 from typing import List, Union
 from fastapi import Depends, FastAPI, HTTPException, status, Request, Security
-from fastapi.encoders import jsonable_encoder
 from fastapi.security import (
     OAuth2PasswordRequestForm,
     SecurityScopes
@@ -205,54 +203,6 @@ async def get_root_node(node_id: str):
             )
         node_id = node.parent
     return node
-
-
-@app.get('/trigger_completed_event/{node_id}')
-async def trigger_completed_event(node_id: str, wait_time_hours: int = 0,
-                                  wait_time_minutes: int = 0,
-                                  wait_time_seconds: int = 0):
-    """Trigger an event when all child nodes are completed of
-       a given node"""
-    try:
-        nodes = await db.find_by_attributes(Node,
-                                            {"parent": ObjectId(node_id)})
-
-    except errors.InvalidId as error:
-        raise HTTPException(
-            status_code=status.HTTP_400_BAD_REQUEST,
-            detail=str(error)
-        ) from error
-
-    if not nodes:
-        raise HTTPException(
-            status_code=status.HTTP_400_BAD_REQUEST,
-            detail=f"No child node found of a given node id:{node_id}"
-        )
-
-    for node in nodes:
-        if node.status == 'pending':
-            timeout = node.created + timedelta(hours=wait_time_hours,
-                                               minutes=wait_time_minutes,
-                                               seconds=wait_time_seconds)
-            await Node.wait_for_node(timeout)
-
-            ret = node.set_timeout_status()
-            if ret:
-                try:
-                    await db.update(node)
-                except ValueError as error:
-                    raise HTTPException(
-                        status_code=status.HTTP_400_BAD_REQUEST,
-                        detail=str(error)
-                    ) from error
-            else:
-                return {"message": "Nodes are not completed yet"}
-
-    operation = 'completed'
-    await pubsub.publish_cloudevent('node', {'op': operation,
-                                             'id': str(node_id),
-                                    'nodes': jsonable_encoder(nodes)})
-    return {"message": "'Event triggered"}
 
 
 @app.post('/node', response_model=Node)

--- a/api/models.py
+++ b/api/models.py
@@ -7,7 +7,7 @@
 """KernelCI API model definitions"""
 
 import asyncio
-from datetime import datetime, timedelta
+from datetime import datetime
 from typing import Optional, Dict, List
 import enum
 from bson import ObjectId, errors
@@ -203,16 +203,6 @@ completed',
         if parent:
             translated['parent'] = ObjectId(parent)
         return translated
-
-    def set_timeout_status(self):
-        """Set Node status to timeout if maximum wait time is over"""
-        if self.status == "pending":
-            current_time = datetime.utcnow()
-            max_wait_time = self.created + timedelta(hours=self.max_wait_time)
-            if current_time > max_wait_time:
-                self.status = "timeout"
-                return True
-        return False
 
     @classmethod
     async def wait_for_node(cls, timeout):


### PR DESCRIPTION
Need to remove method and logic to set node status
to timeout in '/trigger_completed_event' endpoint
as a separate client script will be used
to do so in pipeline.

Fixes: 2e3c506 ("api.main: Add 'trigger_completed_event' endpoint")
Signed-off-by: Jeny Sadadia <jeny.sadadia@collabora.com>