### PR TITLE
T36501 Declare Node.kind to be constant

### DIFF
--- a/api/models.py
+++ b/api/models.py
@@ -126,7 +126,8 @@ class Node(DatabaseModel):
     """KernelCI primitive node object model for generic test results"""
     kind: str = Field(
         default='node',
-        description='Type of the object'
+        description='Type of the object',
+        const=True
     )
     name: str = Field(
         description='Name of the node object'


### PR DESCRIPTION
Allow only default value for 'Node.kind' i.e 'node'.
This is required to get all the node objects based on the kind specified e.g regression nodes will have kind 'regression'.

Signed-off-by: Jeny Sadadia <jeny.sadadia@collabora.com>