### PR TITLE
T36483 Validate node transition

### DIFF
--- a/api/main.py
+++ b/api/main.py
@@ -266,6 +266,13 @@ async def put_node(node_id: str, node: Node, token: str = Depends(get_user)):
     """Update an already added node"""
     try:
         node.id = ObjectId(node_id)
+        node_from_id = await get_node(node.id)
+        is_valid, message = node_from_id.validate_node_transition(node.state)
+        if not is_valid:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail=message
+            )
         obj = await db.update(node)
         operation = 'updated'
     except ValueError as error:

--- a/api/models.py
+++ b/api/models.py
@@ -239,6 +239,19 @@ completed',
             translated['parent'] = ObjectId(parent)
         return translated
 
+    def validate_node_transition(self, new_state):
+        """Validate Node.state transitions"""
+        state_transition_map = {
+            'running': ['available', 'closing', 'done'],
+            'available': ['closing', 'done'],
+            'closing': ['done'],
+            'done': []
+        }
+        valid_states = state_transition_map[self.state]
+        if new_state not in valid_states:
+            return False, f"Transition not allowed with state: {new_state}"
+        return True, "Transition validated successfully"
+
 
 class Hierarchy(BaseModel):
     """Hierarchy of nodes with child nodes"""


### PR DESCRIPTION
Validate values of `Node.status` and `Node.result` before updating the node object.