### PR TITLE
T35078 Set root node status to 'completed'

### DIFF
--- a/api/main.py
+++ b/api/main.py
@@ -236,16 +236,7 @@ async def trigger_completed_event(node_id: str, wait_time_hours: int = 0,
                                                seconds=wait_time_seconds)
             await Node.wait_for_node(timeout)
 
-            ret = node.set_timeout_status()
-            if ret:
-                try:
-                    await db.update(node)
-                except ValueError as error:
-                    raise HTTPException(
-                        status_code=status.HTTP_400_BAD_REQUEST,
-                        detail=str(error)
-                    ) from error
-            else:
+            if node.status == 'pending':
                 return {"message": "Nodes are not completed yet"}
 
     operation = 'completed'

--- a/api/models.py
+++ b/api/models.py
@@ -7,8 +7,8 @@
 """KernelCI API model definitions"""
 
 import asyncio
-from datetime import datetime, timedelta
 from typing import Optional, Dict, List
+from datetime import datetime
 import enum
 from bson import ObjectId, errors
 from pydantic import BaseModel, Field, SecretStr, HttpUrl
@@ -203,16 +203,6 @@ completed',
         if parent:
             translated['parent'] = ObjectId(parent)
         return translated
-
-    def set_timeout_status(self):
-        """Set Node status to timeout if maximum wait time is over"""
-        if self.status == "pending":
-            current_time = datetime.utcnow()
-            max_wait_time = self.created + timedelta(hours=self.max_wait_time)
-            if current_time > max_wait_time:
-                self.status = "timeout"
-                return True
-        return False
 
     @classmethod
     async def wait_for_node(cls, timeout):


### PR DESCRIPTION
Depends on https://github.com/kernelci/kernelci-api/pull/152

A few changes in the `trigger_completed_event` endpoint.
When all child nodes are completed, set root node status to 'completed' from the endpoint. Also, trigger the event.
Moved logic to wait for the node in `trigger_completed` pipeline script.