### PR TITLE
T36848 api.models: rename Node status to 'complete'

### DIFF
--- a/api/models.py
+++ b/api/models.py
@@ -36,7 +36,7 @@ class PyObjectId(ObjectId):
 class StatusValues(enum.Enum):
     """Enumeration to declare values to be used for Node.status"""
 
-    COMPLETED = "completed"
+    COMPLETE = "complete"
     PENDING = "pending"
     TIMEOUT = "timeout"
 


### PR DESCRIPTION
Node.status value 'complete' is more appropriate
than 'completed' to denote completed node.

Signed-off-by: Jeny Sadadia <jeny.sadadia@collabora.com>