### PR TITLE
T36916 Implement pagination for '/nodes' endpoint

### DIFF
--- a/api/models.py
+++ b/api/models.py
@@ -234,6 +234,14 @@ completed',
             translated['parent'] = ObjectId(parent)
         return translated
 
+    @classmethod
+    def filter_params(cls, params: dict):
+        """Drop parameters not matching model fields from the `params`
+        dictionary"""
+        for param in list(params):
+            if param not in cls.__fields__:
+                del params[param]
+
 
 class Regression(Node):
     """API model for regression tracking"""

--- a/api/paginator_models.py
+++ b/api/paginator_models.py
@@ -1,0 +1,22 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+#
+# Copyright (C) 2022 Collabora Limited
+# Author: Jeny Sadadia <jeny.sadadia@collabora.com>
+
+"""Model definitions for pagination"""
+
+from typing import TypeVar
+from fastapi_pagination import LimitOffsetPage
+from bson import ObjectId
+
+
+class PageModel(LimitOffsetPage[TypeVar("T")]):
+    """Model for pagination
+
+    This model is required to serialize paginated model data response"""
+
+    class Config:
+        """Configuration attributes for PageNode"""
+        json_encoders = {
+            ObjectId: str,
+        }

--- a/docker/api/requirements.txt
+++ b/docker/api/requirements.txt
@@ -1,6 +1,7 @@
 aioredis[hiredis]==2.0.0
 cloudevents==1.2.0
 fastapi[all]==0.68.1
+fastapi-pagination==0.9.3
 passlib==1.7.4
 pydantic==1.8.2
 python-jose[cryptography]==3.3.0

--- a/test/test_node_handler.py
+++ b/test/test_node_handler.py
@@ -172,7 +172,7 @@ def test_get_nodes_by_attributes_endpoint_node_not_found(
             )
         print("response.json()", response.json())
         assert response.status_code == 200
-        assert len(response.json()) == 0
+        assert response.json().get('total') == 0
 
 
 def test_get_node_by_id_endpoint(mock_get_current_user, mock_db_find_by_id,
@@ -327,7 +327,7 @@ def test_get_all_nodes_empty_response(mock_get_current_user,
         response = client.get("/nodes")
         print("response.json()", response.json())
         assert response.status_code == 200
-        assert len(response.json()) == 0
+        assert response.json().get('total') == 0
 
 
 def test_get_root_node_endpoint(mock_db_find_by_id, mock_init_sub_id):


### PR DESCRIPTION
Add 'skip' and 'limit' request query parameters to get a desired set of nodes in response from the endpoint.
Need to drop them from 'query_params' dictionary to match the fields with the model. It is required to get objects matching model attributes from the database.