### PR TITLE
api.main: fix user authentication

### DIFF
--- a/api/main.py
+++ b/api/main.py
@@ -75,7 +75,8 @@ async def post_user(
         current_user: User = Security(get_user, scopes=["admin"])):
     """Create new user"""
     try:
-        hashed_password = auth.get_password_hash(str(password.password))
+        hashed_password = auth.get_password_hash(
+                                password.password.get_secret_value())
         obj = await db.create(User(
                                 username=username,
                                 hashed_password=hashed_password,


### PR DESCRIPTION
Use `main.get_password_hash` instead of
`auth.get_password_hash` directly to convert
password from SecretStr to plain text first.

Fixes: 7a67489 ("api/main.py: implement /user endpoint")
Signed-off-by: Jeny Sadadia <jeny.sadadia@collabora.com>