### PR TITLE
api.models: implement new Node.state values

### DIFF
--- a/api/models.py
+++ b/api/models.py
@@ -32,12 +32,13 @@ class PyObjectId(ObjectId):
         return ObjectId(value)
 
 
-class StatusValues(enum.Enum):
-    """Enumeration to declare values to be used for Node.status"""
+class StateValues(enum.Enum):
+    """Enumeration to declare values to be used for Node.state"""
 
-    COMPLETE = "complete"
-    PENDING = "pending"
-    TIMEOUT = "timeout"
+    RUNNING = 'running'
+    AVAILABLE = 'available'
+    CLOSING = 'closing'
+    DONE = 'done'
 
 
 class ResultValues(enum.Enum):
@@ -171,9 +172,9 @@ class Node(DatabaseModel):
     parent: Optional[PyObjectId] = Field(
         description='Parent commit SHA'
     )
-    status: Optional[StatusValues] = Field(
-        default=StatusValues.PENDING,
-        description='Status of node'
+    state: Optional[StateValues] = Field(
+        default=StateValues.RUNNING,
+        description='State of the node'
     )
     result: Optional[ResultValues] = Field(
         description='Result of node'
@@ -204,14 +205,12 @@ completed',
     @classmethod
     def validate_params(cls, params: dict):
         """Validate Node parameters"""
-        status = params.get('status')
-        if status and status not in [status.value
-                                     for status in StatusValues]:
-            return False, f"Invalid status value '{status}'"
+        state = params.get('state')
+        if state and state not in [state.value for state in StateValues]:
+            return False, f"Invalid state value '{state}'"
 
         result = params.get('result')
-        if result and result not in [result.value
-                                     for result in ResultValues]:
+        if result and result not in [result.value for result in ResultValues]:
             return False, f"Invalid result value '{result}'"
 
         parent = params.get('parent')
@@ -257,14 +256,12 @@ class Regression(Node):
         if not ret:
             return ret, msg
 
-        status = params.get('regression_data.status')
-        if status and status not in [status.value
-                                     for status in StatusValues]:
-            return False, f"Invalid status value '{status}'"
+        state = params.get('regression_data.state')
+        if state and state not in [state.value for state in StateValues]:
+            return False, f"Invalid state value '{state}'"
 
         result = params.get('regression_data.result')
-        if result and result not in [result.value
-                                     for result in ResultValues]:
+        if result and result not in [result.value for result in ResultValues]:
             return False, f"Invalid result value '{result}'"
 
         parent = params.get('regression_data.parent')

--- a/doc/overview.md
+++ b/doc/overview.md
@@ -83,7 +83,7 @@ graph LR
   new --> |yes| tarball(Tarball)
   new -.-> |no| trigger
   tarball --> |event: <br /> new revision| runner(Test <br /> Runner)
-  runner --> |event: <br /> test pending| runtime(Runtime <br /> Environment)
+  runner --> |event: <br /> test running| runtime(Runtime <br /> Environment)
   runtime --> |event: <br /> test complete| email(Email <br /> Generator)
 ```
 
@@ -98,14 +98,14 @@ The Trigger step periodically checks whether a new kernel revision has appeared
 on a git branch.  It first gets the revision checksum from the top of the
 branch from the git repo and then queries the API to check whether it has
 already been covered.  If there's no revision entry with this checksum in the
-API, it then pushes one with "pending" state.
+API, it then pushes one with "available" state.
 
 ### Tarball
 
-The Tarball step listens for pub/sub events about new pending revisions.  When
-one is received, typically because the trigger pushed a new revision to the
-API, it then updates a local git checkout of the full kernel source tree.  Then
-it makes a tarball with the source code and pushes it to the storage.  Finally,
+The Tarball step listens for pub/sub events about new revisions.  When one is
+received, typically because the trigger pushed a new revision to the API, it
+then updates a local git checkout of the full kernel source tree.  Then it
+makes a tarball with the source code and pushes it to the storage.  Finally,
 the URL of the tarball is added to the revision data, the status is set to
 "complete" and an update is sent to the API.
 
@@ -114,8 +114,8 @@ the URL of the tarball is added to the revision data, the status is set to
 The Runner step listens for pub/sub events about completed revisions, typically
 following the tarball step.  It will then schedule some tests to be run in
 various runtime environments as defined in the pipeline YAML configuration from
-the Core tools.  An data entry is sent to the API for each test submitted with
-"pending" state.  It's then up to the test in the runtime environment to send
+the Core tools.  A node entry is sent to the API for each test submitted with
+"running" state.  It's then up to the test in the runtime environment to send
 its results to the API and set the final status.
 
 ### Runtime Environment

--- a/test/test_node_handler.py
+++ b/test/test_node_handler.py
@@ -44,7 +44,7 @@ def test_create_node_endpoint(mock_get_current_user, mock_init_sub_id,
             group="debug",
             revision=revision_obj,
             parent=None,
-            status="pending",
+            state="closing",
             result=None,
         )
     mock_db_create.return_value = node_obj
@@ -82,7 +82,7 @@ def test_create_node_endpoint(mock_get_current_user, mock_init_sub_id,
             'parent',
             'result',
             'revision',
-            'status',
+            'state',
             'updated',
         }
 
@@ -111,7 +111,7 @@ def test_get_nodes_by_attributes_endpoint(mock_get_current_user,
             name="checkout",
             revision=revision_obj_1,
             parent="61bda8f2eb1a63d2b7152410",
-            status="pending",
+            state="closing",
             result=None,
         )
     revision_obj_2 = Revision(
@@ -128,7 +128,7 @@ def test_get_nodes_by_attributes_endpoint(mock_get_current_user,
             name="checkout",
             revision=revision_obj_2,
             parent="61bda8f2eb1a63d2b7152410",
-            status="pending",
+            state="closing",
             result=None,
         )
     mock_db_find_by_attributes.return_value = [node_obj_1, node_obj_2]
@@ -137,7 +137,7 @@ def test_get_nodes_by_attributes_endpoint(mock_get_current_user,
         "name": "checkout",
         "revision.tree": "mainline",
         "revision.branch": "master",
-        "status": "pending",
+        "state": "closing",
         "parent": "61bda8f2eb1a63d2b7152410",
     }
     with TestClient(app) as client:
@@ -201,7 +201,7 @@ def test_get_node_by_id_endpoint(mock_get_current_user, mock_db_find_by_id,
             group="blah",
             revision=revision_obj,
             parent=None,
-            status="pending",
+            state="closing",
             result=None,
         )
     mock_db_find_by_id.return_value = node_obj
@@ -221,7 +221,7 @@ def test_get_node_by_id_endpoint(mock_get_current_user, mock_db_find_by_id,
             'parent',
             'result',
             'revision',
-            'status',
+            'state',
             'updated',
         }
 
@@ -268,7 +268,7 @@ def test_get_all_nodes(mock_get_current_user, mock_db_find_by_attributes,
             name="checkout",
             revision=revision_obj_1,
             parent=None,
-            status="pending",
+            state="closing",
             result=None,
         )
     revision_obj_2 = Revision(
@@ -285,7 +285,7 @@ def test_get_all_nodes(mock_get_current_user, mock_db_find_by_attributes,
             name="test_node",
             revision=revision_obj_2,
             parent=None,
-            status="pending",
+            state="closing",
             result=None,
         )
     revision_obj_3 = Revision(
@@ -302,7 +302,7 @@ def test_get_all_nodes(mock_get_current_user, mock_db_find_by_attributes,
             name="test",
             revision=revision_obj_3,
             parent=None,
-            status="pending",
+            state="closing",
             result=None,
         )
     mock_db_find_by_attributes.return_value = [node_obj_1, node_obj_2,
@@ -355,7 +355,7 @@ def test_get_root_node_endpoint(mock_db_find_by_id, mock_init_sub_id):
             name="checkout",
             revision=revision_obj,
             parent="61bda8f2eb1a63d2b7152410",
-            status="pending",
+            state="closing",
             result=None,
         )
     root_node_obj = Node(
@@ -364,7 +364,7 @@ def test_get_root_node_endpoint(mock_db_find_by_id, mock_init_sub_id):
             name="root",
             revision=revision_obj,
             parent=None,
-            status="pending",
+            state="closing",
             result=None,
         )
     mock_db_find_by_id.side_effect = [node_obj, root_node_obj]
@@ -384,7 +384,7 @@ def test_get_root_node_endpoint(mock_db_find_by_id, mock_init_sub_id):
             'parent',
             'result',
             'revision',
-            'status',
+            'state',
             'updated'
         }
 


### PR DESCRIPTION
Replace Node.status with Node.state to make it clear it's about the
state of the Node and not about any pass/fail result.  Update the list
of states to match the new specs.

Signed-off-by: Guillaume Tucker <guillaume.tucker@collabora.com>