### PR TITLE
Add /nodes/{node_id} entry point for submitting hierarchy

### DIFF
--- a/api/models.py
+++ b/api/models.py
@@ -248,6 +248,15 @@ completed',
                 del params[param]
 
 
+class Hierarchy(BaseModel):
+    """Hierarchy of nodes with child nodes"""
+    node: Node
+    child_nodes: List['Hierarchy']
+
+
+Hierarchy.update_forward_refs()
+
+
 class Regression(Node):
     """API model for regression tracking"""
 


### PR DESCRIPTION
Add a Hierarchy model and an entry point for submitting a hierarchy of nodes to be added with an existing root node as the top-level parent.  Implement a `Database.create_hierarchy()` method to create all the node objects in the database accordingly.