### PR TITLE
api.models: rename Node.max_wait_time

### DIFF
--- a/api/models.py
+++ b/api/models.py
@@ -191,7 +191,7 @@ URLs (e.g. URL to binaries or logs)'
         default_factory=datetime.utcnow,
         description='Timestamp when node was last updated'
     )
-    max_wait_time: Optional[float] = Field(
+    timeout: Optional[float] = Field(
         default=24.0,
         description='Maximum time in hours to wait for node to get it \
 completed',

--- a/test/test_node_handler.py
+++ b/test/test_node_handler.py
@@ -77,12 +77,12 @@ def test_create_node_endpoint(mock_get_current_user, mock_init_sub_id,
             'created',
             'group',
             'kind',
-            'max_wait_time',
             'name',
             'parent',
             'result',
             'revision',
             'state',
+            'timeout',
             'updated',
         }
 
@@ -216,12 +216,12 @@ def test_get_node_by_id_endpoint(mock_get_current_user, mock_db_find_by_id,
             'created',
             'group',
             'kind',
-            'max_wait_time',
             'name',
             'parent',
             'result',
             'revision',
             'state',
+            'timeout',
             'updated',
         }
 
@@ -379,12 +379,12 @@ def test_get_root_node_endpoint(mock_db_find_by_id, mock_init_sub_id):
             'created',
             'group',
             'kind',
-            'max_wait_time',
             'name',
             'parent',
             'result',
             'revision',
             'state',
+            'timeout',
             'updated'
         }
 


### PR DESCRIPTION
Rename the Node field `max_wait_time` to
`timeout` to be more appropriate.

Signed-off-by: Jeny Sadadia <jeny.sadadia@collabora.com>