### PR TITLE
T37711 Fix pagination integration with Mongo DB

### DIFF
--- a/api/db.py
+++ b/api/db.py
@@ -7,6 +7,7 @@
 """Database abstraction"""
 
 from bson import ObjectId
+from fastapi_pagination.ext.motor import paginate
 from motor import motor_asyncio
 from .models import Hierarchy, Node, User, Regression
 
@@ -68,11 +69,13 @@ class Database:
         """Find objects with matching attributes
 
         Find all objects with attributes matching the key/value pairs in the
-        attributes dictionary and return them as a list.
+        attributes dictionary using pagination and return the paginated
+        response.
+        The response dictionary will include 'items', 'total', 'limit',
+        and 'offset' keys.
         """
         col = self._get_collection(model)
-        data = await col.find(attributes).to_list(None)
-        return list(model(**obj) for obj in data)
+        return await paginate(collection=col, query_filter=attributes)
 
     async def create(self, obj):
         """Create a database document from a model object

--- a/api/main.py
+++ b/api/main.py
@@ -16,7 +16,6 @@ from fastapi import (
     status,
     Request,
     Security,
-    Query
 )
 from fastapi.security import (
     OAuth2PasswordRequestForm,
@@ -194,9 +193,7 @@ async def get_node(node_id: str, kind: str = "node"):
 
 
 @app.get('/nodes', response_model=PageModel)
-async def get_nodes(request: Request, kind: str = "node",
-                    offset: int = Query(default=0, ge=0),
-                    limit: int = Query(default=50, ge=1)):
+async def get_nodes(request: Request, kind: str = "node"):
     """Get all the nodes if no request parameters have passed.
        Get all the matching nodes otherwise, within the pagination limit."""
     model = get_model_from_kind(kind)

--- a/api/main.py
+++ b/api/main.py
@@ -22,7 +22,7 @@ from fastapi.security import (
     OAuth2PasswordRequestForm,
     SecurityScopes
 )
-from fastapi_pagination import add_pagination, paginate
+from fastapi_pagination import add_pagination
 from bson import ObjectId, errors
 from pymongo.errors import DuplicateKeyError
 from .auth import Authentication, Token
@@ -220,7 +220,7 @@ async def get_nodes(request: Request, kind: str = "node",
         )
 
     translated_params = model.translate_fields(query_params)
-    return paginate(await db.find_by_attributes(model, translated_params))
+    return await db.find_by_attributes(model, translated_params)
 
 add_pagination(app)
 

--- a/test/test_node_handler.py
+++ b/test/test_node_handler.py
@@ -136,7 +136,12 @@ def test_get_nodes_by_attributes_endpoint(mock_get_current_user,
             state="closing",
             result=None,
         )
-    mock_db_find_by_attributes.return_value = [node_obj_1, node_obj_2]
+    mock_db_find_by_attributes.return_value = {
+        'items': [node_obj_1, node_obj_2],
+        'total': 2,
+        'limit': 50,
+        'offset': 0
+    }
 
     params = {
         "name": "checkout",
@@ -152,7 +157,7 @@ def test_get_nodes_by_attributes_endpoint(mock_get_current_user,
             )
         print("response.json()", response.json())
         assert response.status_code == 200
-        assert len(response.json()) > 0
+        assert len(response.json()['items']) > 0
 
 
 def test_get_nodes_by_attributes_endpoint_node_not_found(
@@ -166,7 +171,13 @@ def test_get_nodes_by_attributes_endpoint_node_not_found(
         HTTP Response Code 200 OK
         Empty list
     """
-    mock_db_find_by_attributes.return_value = []
+
+    mock_db_find_by_attributes.return_value = {
+        'items': [],
+        'total': 0,
+        'limit': 50,
+        'offset': 0
+    }
 
     params = {
         "name": "checkout",
@@ -315,8 +326,13 @@ def test_get_all_nodes(mock_get_current_user, mock_db_find_by_attributes,
             state="closing",
             result=None,
         )
-    mock_db_find_by_attributes.return_value = [node_obj_1, node_obj_2,
-                                               node_obj_3]
+
+    mock_db_find_by_attributes.return_value = {
+        'items': [node_obj_1, node_obj_2, node_obj_3],
+        'total': 3,
+        'limit': 50,
+        'offset': 0
+    }
 
     with TestClient(app) as client:
         response = client.get("/nodes")
@@ -335,7 +351,12 @@ def test_get_all_nodes_empty_response(mock_get_current_user,
         HTTP Response Code 200 OK
         Empty list as no Node object is added.
     """
-    mock_db_find_by_attributes.return_value = []
+    mock_db_find_by_attributes.return_value = {
+        'items': [],
+        'total': 0,
+        'limit': 50,
+        'offset': 0
+    }
 
     with TestClient(app) as client:
         response = client.get("/nodes")


### PR DESCRIPTION
Fixes https://github.com/kernelci/kernelci-api/issues/176

api.db: use pagination in `Database.find_by_attributes`
api.main: Drop the call to `paginate` method from `get_nodes`

