### PR TITLE
T37965 models: store node expiry timestamp to `Node.timeout`

### DIFF
--- a/api/db.py
+++ b/api/db.py
@@ -97,6 +97,7 @@ class Database:
         if obj.id is not None:
             raise ValueError(f"Object cannot be created with id: {obj.id}")
         delattr(obj, 'id')
+        obj.set_timeout()
         col = self._get_collection(obj.__class__)
         res = await col.insert_one(obj.dict(by_alias=True))
         obj.id = res.inserted_id
@@ -116,6 +117,7 @@ class Database:
                 raise ValueError(f"No object found with id: {obj.id}")
         else:
             delattr(obj, 'id')
+            obj.set_timeout()
             res = await col.insert_one(obj.dict(by_alias=True))
             obj.id = res.inserted_id
         obj = cls(**await col.find_one({'_id': ObjectId(obj.id)}))

--- a/api/models.py
+++ b/api/models.py
@@ -6,7 +6,7 @@
 
 """KernelCI API model definitions"""
 
-from datetime import datetime
+from datetime import datetime, timedelta
 from typing import Optional, Dict, List
 import enum
 from bson import ObjectId, errors
@@ -194,13 +194,17 @@ URLs (e.g. URL to binaries or logs)'
         default_factory=datetime.utcnow,
         description='Timestamp when node was last updated'
     )
-    timeout: Optional[float] = Field(
-        default=24.0,
-        description='Maximum time in hours to wait for node to get it \
-completed',
-        ge=0.0,
-        le=24.0
+    timeout: Optional[datetime] = Field(
+        description='Node expiry timestamp'
     )
+
+    def set_timeout(self, hours: int = 24):
+        """Set Node timeout (expiry timestamp)
+
+        After the node's creation, it will timeout after the number
+        of hours (default: 24) provided.
+        """
+        self.timeout = self.created + timedelta(hours=hours)
 
     def update(self):
         self.updated = datetime.utcnow()


### PR DESCRIPTION
Instead of calculating expiry timestamp from
`Node.timeout` field to check whether the node
needs to change its state to `done`, directly
store expiry timestamp to the field using
`Node.set_timeout` method.

Signed-off-by: Jeny Sadadia <jeny.sadadia@collabora.com>