### PR TITLE
T38131 api.models: fix node state validation

### DIFF
--- a/api/main.py
+++ b/api/main.py
@@ -287,6 +287,11 @@ async def put_node(node_id: str, node: Node, token: str = Depends(get_user)):
     try:
         node.id = ObjectId(node_id)
         node_from_id = await get_node(node.id)
+        if not node_from_id:
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND,
+                detail=f"Node not found with id: {node.id}"
+            )
         is_valid, message = node_from_id.validate_node_state_transition(
             node.state)
         if not is_valid:

--- a/api/main.py
+++ b/api/main.py
@@ -287,7 +287,8 @@ async def put_node(node_id: str, node: Node, token: str = Depends(get_user)):
     try:
         node.id = ObjectId(node_id)
         node_from_id = await get_node(node.id)
-        is_valid, message = node_from_id.validate_node_transition(node.state)
+        is_valid, message = node_from_id.validate_node_state_transition(
+            node.state)
         if not is_valid:
             raise HTTPException(
                 status_code=status.HTTP_400_BAD_REQUEST,

--- a/api/main.py
+++ b/api/main.py
@@ -286,7 +286,7 @@ async def put_node(node_id: str, node: Node, token: str = Depends(get_user)):
     """Update an already added node"""
     try:
         node.id = ObjectId(node_id)
-        node_from_id = await get_node(node.id)
+        node_from_id = await db.find_by_id(Node, node_id)
         if not node_from_id:
             raise HTTPException(
                 status_code=status.HTTP_404_NOT_FOUND,
@@ -301,7 +301,7 @@ async def put_node(node_id: str, node: Node, token: str = Depends(get_user)):
             )
         obj = await db.update(node)
         operation = 'updated'
-    except ValueError as error:
+    except (ValueError, errors.InvalidId) as error:
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
             detail=str(error)

--- a/api/models.py
+++ b/api/models.py
@@ -239,8 +239,11 @@ completed',
             translated['parent'] = ObjectId(parent)
         return translated
 
-    def validate_node_transition(self, new_state):
+    def validate_node_state_transition(self, new_state):
         """Validate Node.state transitions"""
+        if new_state == self.state:
+            return True, f"Transition to the same state: { new_state }. \
+                No validation is required."
         state_transition_map = {
             'running': ['available', 'closing', 'done'],
             'available': ['closing', 'done'],


### PR DESCRIPTION
Need to handle a case where node update operation
do not change the node state.

Fixes: 1f96e91 ("api.models: implement `Node.validate_node_transition`")
Signed-off-by: Jeny Sadadia <jeny.sadadia@collabora.com>