### PR TITLE
T38061 Validate parent in POST node handler

### DIFF
--- a/api/main.py
+++ b/api/main.py
@@ -269,6 +269,19 @@ async def get_root_node(node_id: str):
 async def post_node(node: Node, token: str = Depends(get_user)):
     """Create a new node"""
     try:
+        if node.parent:
+            parent = await db.find_by_id(Node, node.parent)
+            if not parent:
+                raise HTTPException(
+                    status_code=status.HTTP_404_NOT_FOUND,
+                    detail=f"Parent not found with id: {node.parent}"
+                )
+            is_valid, message = parent.validate_parent()
+            if not is_valid:
+                raise HTTPException(
+                    status_code=status.HTTP_400_BAD_REQUEST,
+                    detail=message
+                )
         obj = await db.create(node)
         operation = 'created'
     except ValueError as error:

--- a/api/models.py
+++ b/api/models.py
@@ -256,6 +256,13 @@ available state'
             return False, f"Transition not allowed with state: {new_state}"
         return True, "Transition validated successfully"
 
+    def validate_parent(self):
+        """Validate the parent node's state before creating child nodes"""
+        if self.state != 'available':
+            return False, f"The node is unavailable to create child node: \
+{self.id}"
+        return True, f"The node is available to create child node: {self.id}"
+
 
 class Hierarchy(BaseModel):
     """Hierarchy of nodes with child nodes"""


### PR DESCRIPTION
Implement a method to check if the node is available to create child nodes. This is needed to avoid the creation of child nodes if the parent is still running or closing.