### PR TITLE
T38189 Add support for schema migrations

### DIFF
--- a/doc/api-details.md
+++ b/doc/api-details.md
@@ -1,6 +1,6 @@
 ---
 title: "API details"
-date: 2022-08-23
+date: 2022-11-25
 description: "KernelCI API building blocks"
 weight: 3
 ---
@@ -254,6 +254,59 @@ timeout
   its current state.  The main reasons why this is needed are for when a node
   gets stuck and never completes its job, or while waiting for child nodes to
   complete.
+
+
+## Migrations
+
+Migrations are required to propagate the changes made to API models to the database like updating or deleting a model field or a model.
+
+[`pymongo-migrate`](https://github.com/stxnext/pymongo-migrate) package has been integrated to enable migration support in the API.
+
+Use the below command to run migration from the `api` Docker container.
+```
+$ docker-compose exec api /bin/sh -c 'pymongo-migrate migrate -u mongodb://db/kernelci -m migrations -v'
+2022-11-25 06:12:17,996 [DEBUG]  Migration target not specified, assuming upgrade
+Command find#1957747793 STARTED
+SON([('find', 'pymongo_migrate'), ('filter', {'name': '20221014061654_set_timeout'}), ('limit', 1), ('singleBatch', True), ('lsid', {'id': Binary(b'7\x18\xe4\xe7\xd0\x88Gc\xafq\x0f[\x8b\x8d\xec\xde', 4)}), ('$db', 'kernelci'), ('$readPreference', {'mode': 'primaryPreferred'})])
+Command find#1957747793 SUCCEEDED in 215us
+2022-11-25 06:12:17,998 [INFO ]  Running upgrade migration '20221014061654_set_timeout'
+Command find#424238335 STARTED
+SON([('find', 'node'), ('filter', {}), ('lsid', {'id': Binary(b'7\x18\xe4\xe7\xd0\x88Gc\xafq\x0f[\x8b\x8d\xec\xde', 4)}), ('$db', 'kernelci'), ('$readPreference', {'mode': 'primaryPreferred'})])
+Command find#424238335 SUCCEEDED in 4404us
+Command update#719885386 STARTED
+SON([('update', 'node'), ('ordered', True), ('lsid', {'id': Binary(b'7\x18\xe4\xe7\xd0\x88Gc\xafq\x0f[\x8b\x8d\xec\xde', 4)}), ('$db', 'kernelci'), ('$readPreference', {'mode': 'primary'}), ('updates', [SON([('q', {'_id': ObjectId('63720d307d572b5aa15462f4')}), ('u', {'$set': {'timeout': datetime.datetime(2022, 11, 14, 15, 41, 4, 175000)}}), ('multi', False), ('upsert', False)])])])
+Command update#719885386 SUCCEEDED in 989us
+Command update#1649760492 STARTED
+SON([('update', 'node'), ('ordered', True), ('lsid', {'id': Binary(b'7\x18\xe4\xe7\xd0\x88Gc\xafq\x0f[\x8b\x8d\xec\xde', 4)}), ('$db', 'kernelci'), ('$readPreference', {'mode': 'primary'}), ('updates', [SON([('q', {'_id': ObjectId('63720d317d572b5aa15462f5')}), ('u', {'$set': {'timeout': datetime.datetime(2022, 11, 14, 15, 41, 5, 454000)}}), ('multi', False), ('upsert', False)])])])
+Command update#1649760492 SUCCEEDED in 151us
+```
+
+The above command will run the necessary `upgrade` for the migrations stored in `migrations` directory.
+If migration target is specified, it will run the necessary `upgrade` or `downgrade` to reach the target.
+
+The status of migration can be found with the below command:
+```
+$ docker-compose exec api /bin/sh -c 'pymongo-migrate show -u mongodb://db/kernelci -m migrations -v'
+Migration name            	Applied timestamp
+Command find#1957747793 STARTED
+SON([('find', 'pymongo_migrate'), ('filter', {'name': '20221014061654_set_timeout'}), ('limit', 1), ('singleBatch', True), ('lsid', {'id': Binary(b'\x1e\x0b"M\x1f\xb3N\xf4\xa3\x00\xaa\xff]c\xf8\xe5', 4)}), ('$db', 'kernelci'), ('$readPreference', {'mode': 'primaryPreferred'})])
+Command find#1957747793 SUCCEEDED in 228us
+20221014061654_set_timeout	2022-11-25T07:00:14.923000+00:00
+```
+
+If the `upgrade` has already been applied, `downgrade` can be run using the below command:
+```
+$ docker-compose exec api /bin/sh -c 'pymongo-migrate downgrade -u mongodb://db/kernelci -m migrations -v'
+Command find#1957747793 STARTED
+SON([('find', 'pymongo_migrate'), ('filter', {'name': '20221014061654_set_timeout'}), ('limit', 1), ('singleBatch', True), ('lsid', {'id': Binary(b'\x0c}X\x9d\xe9{O\xd5\x85\xb3\x904\xa2R\x89i', 4)}), ('$db', 'kernelci'), ('$readPreference', {'mode': 'primaryPreferred'})])
+Command find#1957747793 SUCCEEDED in 237us
+2022-11-25 07:07:21,857 [INFO ]  Running downgrade migration '20221014061654_set_timeout'
+2022-11-25 07:07:21,858 [INFO ]  Execution time of '20221014061654_set_timeout': 1.049041748046875e-05 seconds
+Command update#424238335 STARTED
+SON([('update', 'pymongo_migrate'), ('ordered', True), ('lsid', {'id': Binary(b'\x0c}X\x9d\xe9{O\xd5\x85\xb3\x904\xa2R\x89i', 4)}), ('$db', 'kernelci'), ('$readPreference', {'mode': 'primary'}), ('updates', [SON([('q', {'name': '20221014061654_set_timeout'}), ('u', {'name': '20221014061654_set_timeout', 'applied': None}), ('multi', False), ('upsert', True)])])])
+Command update#424238335 SUCCEEDED in 279us
+```
+
 
 ## Pub/Sub and CloudEvent
 

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -15,6 +15,7 @@ services:
     volumes:
       - './api:/home/kernelci/api'
       - './test:/home/kernelci/test'
+      - './migrations:/home/kernelci/migrations'
     ports:
       - '${API_HOST_PORT:-8001}:8000'
     env_file:

--- a/docker/api/requirements.txt
+++ b/docker/api/requirements.txt
@@ -7,3 +7,4 @@ pydantic==1.8.2
 python-jose[cryptography]==3.3.0
 uvicorn[standard]==0.13.4
 motor==2.5.1
+pymongo-migrate==0.11.0

--- a/migrations/20221014061654_set_timeout.py
+++ b/migrations/20221014061654_set_timeout.py
@@ -1,0 +1,33 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+#
+# Copyright (C) 2022 Collabora Limited
+# Author: Jeny Sadadia <jeny.sadadia@collabora.com>
+
+"""
+Migration to update Node.timeout
+"""
+
+from datetime import timedelta
+
+name = '20221014061654_set_timeout'
+dependencies = []
+
+
+def upgrade(db: "pymongo.database.Database"):
+    nodes = db.node.find()
+    for node in nodes:
+        timeout = node['created'] + timedelta(hours=6)
+        db.node.update_one(
+            {
+                "_id": node['_id']
+            },
+            {
+                "$set": {
+                    "timeout": timeout
+                }
+            },
+        )
+
+
+def downgrade(db: "pymongo.database.Database"):
+    pass


### PR DESCRIPTION
- Since the `timeout` field is updated to store the node expiry timestamp, need to add a migration file to update existing Node objects.
- Use `pymongo-migrate` package to implement schema migration mechanism.
- Mount `migrations` volume to api container.
- Add command to run migrations on api container startup.