### PR TITLE
T36848 api.models: add 'SKIP' and 'INCOMPLETE' node result

### DIFF
--- a/api/models.py
+++ b/api/models.py
@@ -44,8 +44,10 @@ class StateValues(enum.Enum):
 class ResultValues(enum.Enum):
     """Enumeration to declare values to be used for Node.result"""
 
-    PASS = "pass"
-    FAIL = "fail"
+    PASS = 'pass'
+    FAIL = 'fail'
+    SKIP = 'skip'
+    INCOMPLETE = 'incomplete'
 
 
 class ModelId(BaseModel):


### PR DESCRIPTION
Considering the possibility of skipped tests with certain test suite (for instance, fstests) we need to add `Node.result` value for it.
We also need to add a result value to denote node timeout.
As a result, we need to add 'SKIP' and 'INCOMPLETE' values to `ResultValues` to denote skipped tests and incompleted nodes respectively.

Signed-off-by: Jeny Sadadia <jeny.sadadia@collabora.com>