### PR TITLE
T38595 api.models: fix `/user` endpoint failure

### DIFF
--- a/api/db.py
+++ b/api/db.py
@@ -97,7 +97,7 @@ class Database:
         if obj.id is not None:
             raise ValueError(f"Object cannot be created with id: {obj.id}")
         delattr(obj, 'id')
-        obj.set_timeout()
+        obj.set_timeout(hours=24)
         col = self._get_collection(obj.__class__)
         res = await col.insert_one(obj.dict(by_alias=True))
         obj.id = res.inserted_id
@@ -117,7 +117,7 @@ class Database:
                 raise ValueError(f"No object found with id: {obj.id}")
         else:
             delattr(obj, 'id')
-            obj.set_timeout()
+            obj.set_timeout(hours=24)
             res = await col.insert_one(obj.dict(by_alias=True))
             obj.id = res.inserted_id
         obj = cls(**await col.find_one({'_id': ObjectId(obj.id)}))

--- a/api/models.py
+++ b/api/models.py
@@ -91,6 +91,9 @@ class DatabaseModel(ModelId):
     def create_indexes(cls, collection):
         """Method to create indexes"""
 
+    def set_timeout(self, hours: int):
+        """Method to set model timeout"""
+
 
 class User(DatabaseModel):
     """API user model"""


### PR DESCRIPTION
Fixes https://github.com/kernelci/kernelci-api/issues/194

Fix error "AttributeError: 'User' object has no attribute 'set_timeout'" when trying to create new users using `/user` endpoint.
Need to add method `set_timeout` to `DatabaseModel` to fix `/user` endpoint failure. The `set_timeout` is being invoked while creating models in
`Database.create`. Hence, need to add it to the
parent class of `User` to fix the issue.

Fixes: 98db8b3 ("db: set timeout upon node creation")
Signed-off-by: Jeny Sadadia <jeny.sadadia@collabora.com>