### PR TITLE
Fix timeout value handling in API

### DIFF
--- a/api/db.py
+++ b/api/db.py
@@ -97,7 +97,6 @@ class Database:
         if obj.id is not None:
             raise ValueError(f"Object cannot be created with id: {obj.id}")
         delattr(obj, 'id')
-        obj.set_timeout(hours=24)
         col = self._get_collection(obj.__class__)
         res = await col.insert_one(obj.dict(by_alias=True))
         obj.id = res.inserted_id
@@ -117,7 +116,6 @@ class Database:
                 raise ValueError(f"No object found with id: {obj.id}")
         else:
             delattr(obj, 'id')
-            obj.set_timeout(hours=24)
             res = await col.insert_one(obj.dict(by_alias=True))
             obj.id = res.inserted_id
         obj = cls(**await col.find_one({'_id': ObjectId(obj.id)}))

--- a/api/models.py
+++ b/api/models.py
@@ -158,6 +158,28 @@ class Revision(BaseModel):
     )
 
 
+class DefaultTimeout:
+    """Helper to create default values for timeout fields
+
+    The `hours` and `minutes` provided are used to create a `timedelta` object
+    available in the `.delta` attribute.  This can then be used to get a
+    timeout value used as a default when defining a non-optional field in a
+    model with the `.get_timeout()` method.
+    """
+
+    def __init__(self, hours=0, minutes=0):
+        self._delta = timedelta(hours=hours, minutes=minutes)
+
+    @property
+    def delta(self):
+        """Get the timedelta set in this object"""
+        return self._delta
+
+    def get_timeout(self):
+        """Get a timeout timestamp with current time and delta"""
+        return datetime.utcnow() + self.delta
+
+
 class Node(DatabaseModel):
     """KernelCI primitive node object model for generic test results"""
     kind: str = Field(

--- a/api/models.py
+++ b/api/models.py
@@ -221,7 +221,8 @@ URLs (e.g. URL to binaries or logs)'
         default_factory=datetime.utcnow,
         description='Timestamp when node was last updated'
     )
-    timeout: Optional[datetime] = Field(
+    timeout: datetime = Field(
+        default_factory=DefaultTimeout(hours=6).get_timeout,
         description='Node expiry timestamp'
     )
     holdoff: Optional[datetime] = Field(

--- a/api/models.py
+++ b/api/models.py
@@ -93,9 +93,6 @@ class DatabaseModel(ModelId):
     def create_indexes(cls, collection):
         """Method to create indexes"""
 
-    def set_timeout(self, hours: int):
-        """Method to set model timeout"""
-
 
 class User(DatabaseModel):
     """API user model"""
@@ -229,14 +226,6 @@ URLs (e.g. URL to binaries or logs)'
         description='Holdoff expiry timestamp for node to be in \
 available state'
     )
-
-    def set_timeout(self, hours: int = 24):
-        """Set Node timeout (expiry timestamp)
-
-        After the node's creation, it will timeout after the number
-        of hours (default: 24) provided.
-        """
-        self.timeout = self.created + timedelta(hours=hours)
 
     def update(self):
         self.updated = datetime.utcnow()

--- a/api/models.py
+++ b/api/models.py
@@ -180,7 +180,7 @@ class Node(DatabaseModel):
     parent: Optional[PyObjectId] = Field(
         description='Parent commit SHA'
     )
-    state: Optional[StateValues] = Field(
+    state: StateValues = Field(
         default=StateValues.RUNNING,
         description='State of the node'
     )
@@ -191,11 +191,11 @@ class Node(DatabaseModel):
         description='Dictionary with names mapping to node associated \
 URLs (e.g. URL to binaries or logs)'
     )
-    created: Optional[datetime] = Field(
+    created: datetime = Field(
         default_factory=datetime.utcnow,
         description='Timestamp of node creation'
     )
-    updated: Optional[datetime] = Field(
+    updated: datetime = Field(
         default_factory=datetime.utcnow,
         description='Timestamp when node was last updated'
     )

--- a/api/models.py
+++ b/api/models.py
@@ -223,8 +223,7 @@ URLs (e.g. URL to binaries or logs)'
         description='Node expiry timestamp'
     )
     holdoff: Optional[datetime] = Field(
-        description='Holdoff expiry timestamp for node to be in \
-available state'
+        description='Node expiry timestamp while in Available state'
     )
 
     def update(self):


### PR DESCRIPTION
Rather than implicitly setting the timeout to a fixed value in the `Database` class, set a default value of 6h in the Node base model and allow the user to set it to any arbitrary value.  Also drop the `Optional` hints for mandatory fields including `timeout`.