### PR TITLE
T39420 Improve request parameter validation

### DIFF
--- a/api/main.py
+++ b/api/main.py
@@ -219,14 +219,9 @@ async def get_nodes(request: Request, kind: str = "node"):
         query_params.pop(pg_key, None)
 
     query_params = await translate_null_query_params(query_params)
-    is_valid, msg = model.validate_params(query_params)
-    if not is_valid:
-        raise HTTPException(
-                status_code=status.HTTP_400_BAD_REQUEST,
-                detail=f"Invalid request parameters: {msg}"
-        )
 
     try:
+        model.validate_params(query_params)
         translated_params = model.translate_fields(query_params)
         return await db.find_by_attributes(model, translated_params)
     except ValueError as error:
@@ -252,14 +247,9 @@ async def get_nodes_count(request: Request, kind: str = "node"):
     query_params = dict(request.query_params)
 
     query_params = await translate_null_query_params(query_params)
-    is_valid, msg = model.validate_params(query_params)
-    if not is_valid:
-        raise HTTPException(
-                status_code=status.HTTP_400_BAD_REQUEST,
-                detail=f"Invalid request parameters: {msg}"
-            )
 
     try:
+        model.validate_params(query_params)
         translated_params = model.translate_fields(query_params)
         return await db.count(model, translated_params)
     except ValueError as error:

--- a/api/main.py
+++ b/api/main.py
@@ -188,16 +188,16 @@ async def get_node(node_id: str, kind: str = "node"):
     """Get node information from the provided node id"""
     try:
         model = get_model_from_kind(kind)
-        if model is None:
-            raise HTTPException(
-                status_code=status.HTTP_400_BAD_REQUEST,
-                detail=f"Invalid kind: {kind}"
-            )
         return await db.find_by_id(model, node_id)
     except errors.InvalidId as error:
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
             detail=str(error)
+        ) from error
+    except KeyError as error:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"Node not found with the kind: {str(error)}"
         ) from error
 
 
@@ -205,13 +205,6 @@ async def get_node(node_id: str, kind: str = "node"):
 async def get_nodes(request: Request, kind: str = "node"):
     """Get all the nodes if no request parameters have passed.
        Get all the matching nodes otherwise, within the pagination limit."""
-    model = get_model_from_kind(kind)
-    if model is None:
-        raise HTTPException(
-            status_code=status.HTTP_400_BAD_REQUEST,
-            detail=f"Invalid kind: {kind}"
-        )
-
     query_params = dict(request.query_params)
 
     # Drop pagination parameters from query as they're already in arguments
@@ -221,6 +214,7 @@ async def get_nodes(request: Request, kind: str = "node"):
     query_params = await translate_null_query_params(query_params)
 
     try:
+        model = get_model_from_kind(kind)
         model.validate_params(query_params)
         translated_params = model.translate_fields(query_params)
         return await db.find_by_attributes(model, translated_params)
@@ -228,6 +222,11 @@ async def get_nodes(request: Request, kind: str = "node"):
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
             detail=str(error)
+        ) from error
+    except KeyError as error:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"Node not found with the kind: {str(error)}"
         ) from error
 
 add_pagination(app)
@@ -237,18 +236,12 @@ add_pagination(app)
 async def get_nodes_count(request: Request, kind: str = "node"):
     """Get the count of all the nodes if no request parameters have passed.
        Get the count of all the matching nodes otherwise."""
-    model = get_model_from_kind(kind)
-    if model is None:
-        raise HTTPException(
-            status_code=status.HTTP_400_BAD_REQUEST,
-            detail=f"Invalid kind: {kind}"
-        )
-
     query_params = dict(request.query_params)
 
     query_params = await translate_null_query_params(query_params)
 
     try:
+        model = get_model_from_kind(kind)
         model.validate_params(query_params)
         translated_params = model.translate_fields(query_params)
         return await db.count(model, translated_params)
@@ -256,6 +249,11 @@ async def get_nodes_count(request: Request, kind: str = "node"):
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
             detail=str(error)
+        ) from error
+    except KeyError as error:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"Node not found with the kind: {str(error)}"
         ) from error
 
 

--- a/api/main.py
+++ b/api/main.py
@@ -288,12 +288,7 @@ async def post_node(node: Node, token: str = Depends(get_user)):
                     status_code=status.HTTP_404_NOT_FOUND,
                     detail=f"Parent not found with id: {node.parent}"
                 )
-            is_valid, message = parent.validate_parent()
-            if not is_valid:
-                raise HTTPException(
-                    status_code=status.HTTP_400_BAD_REQUEST,
-                    detail=message
-                )
+            parent.validate_parent()
         obj = await db.create(node)
         operation = 'created'
     except ValueError as error:

--- a/api/models.py
+++ b/api/models.py
@@ -344,11 +344,8 @@ class Regression(Node):
 
 def get_model_from_kind(kind: str):
     """Get model from kind parameter"""
-    try:
-        models = {
+    models = {
             "node": Node,
             "regression": Regression
         }
-        return models[kind]
-    except KeyError:
-        return None
+    return models[kind]

--- a/api/models.py
+++ b/api/models.py
@@ -28,7 +28,7 @@ class PyObjectId(ObjectId):
     def validate(cls, value):
         """Validate the value of the ObjectId"""
         if not ObjectId.is_valid(value):
-            raise ValueError('Invalid ObjectId')
+            raise ValueError(f"Invalid ObjectId: {value}")
         return ObjectId(value)
 
 

--- a/api/models.py
+++ b/api/models.py
@@ -304,9 +304,8 @@ URLs (e.g. URL to binaries or logs)'
     def validate_parent(self):
         """Validate the parent node's state before creating child nodes"""
         if self.state != 'available':
-            return False, f"The node is unavailable to create child node: \
-{self.id}"
-        return True, f"The node is available to create child node: {self.id}"
+            raise ValueError(f"The node is unavailable to create child node: \
+{self.id}")
 
 
 class Hierarchy(BaseModel):


### PR DESCRIPTION
Instead of returning `is_valid` flag and message from `validate_params`, raise `ValueError` if invalid state, result, or parent is received in the request query params.
Dropped mechanism to check the validation flag and move the method to try-except block to catch ValueError exceptions in `get_nodes` and `get_nodes_count` handlers.