### PR TITLE
T39493 Implement request query param translation for Regression model

### DIFF
--- a/api/models.py
+++ b/api/models.py
@@ -361,6 +361,19 @@ class Regression(Node):
         if parent:
             PyObjectId.validate(parent)
 
+    @classmethod
+    def translate_fields(cls, params: dict):
+        """Translate regression parameters"""
+        translated = Node.translate_fields(params)
+        parent = translated.get('regression_data.parent')
+        if parent:
+            translated['regression_data.parent'] = ObjectId(parent)
+        timestamp_fields = (
+            'regression_data.created', 'regression_data.updated',
+            'regression_data.timeout', 'regression_data.holdoff'
+        )
+        return Node.translate_timestamp_fields(translated, timestamp_fields)
+
 
 def get_model_from_kind(kind: str):
     """Get model from kind parameter"""

--- a/api/models.py
+++ b/api/models.py
@@ -251,6 +251,23 @@ URLs (e.g. URL to binaries or logs)'
             PyObjectId.validate(parent)
 
     @classmethod
+    def translate_fields_with_operators(cls, params, translated):
+        """Translate fields with comparison operator
+
+        The request query parameters can be provided with comparison operators
+        like `lt`, `gt`, `lte`, and `gte` with `param__operator=value`
+        format. This method will translate the parameter to
+        `param={operator: value}`.
+        """
+        for key in params.keys():
+            field = key.split('__')
+            if len(field) == 2:
+                translated[field[0]] = {
+                    field[1]: translated[key]
+                }
+                del translated[key]
+
+    @classmethod
     def translate_fields(cls, params: dict):
         """Translate fields in `params` into objects as applicable
 

--- a/api/models.py
+++ b/api/models.py
@@ -268,6 +268,27 @@ URLs (e.g. URL to binaries or logs)'
                 del translated[key]
 
     @classmethod
+    def translate_timestamp_fields(cls, translated,
+                                   timestamp_fields):
+        """Translate timestamp fields
+
+        ISOformat timestamp fields will be translated to Date object.
+        This supports translation of fields provided along with operators
+        as well e.g field={operator: value}.
+        """
+        params = translated.copy()
+        for key, value in params.items():
+            if key in timestamp_fields:
+                if isinstance(value, dict):
+                    for sub_key, sub_value in value.items():
+                        translated[key] = {
+                            sub_key: datetime.fromisoformat(sub_value)
+                        }
+                else:
+                    translated[key] = datetime.fromisoformat(value)
+        return translated
+
+    @classmethod
     def translate_fields(cls, params: dict):
         """Translate fields in `params` into objects as applicable
 

--- a/api/models.py
+++ b/api/models.py
@@ -303,25 +303,8 @@ URLs (e.g. URL to binaries or logs)'
             translated['parent'] = ObjectId(parent)
 
         timestamp_fields = ('created', 'updated', 'timeout', 'holdoff')
-        # Split params with `__` in key and translate timestamp fields
-        for key in params.keys():
-            if translated[key] is None:
-                continue
-            if key in timestamp_fields:
-                translated[key] = datetime.fromisoformat(translated[key])
-            field = key.split('__')
-            if len(field) == 2:
-                if field[0] in timestamp_fields:
-                    translated[field[0]] = {
-                        field[1]: datetime.fromisoformat(translated[key])
-                    }
-                else:
-                    translated[field[0]] = {
-                        field[1]: translated[key]
-                    }
-                del translated[key]
-
-        return translated
+        Node.translate_fields_with_operators(params, translated)
+        return Node.translate_timestamp_fields(translated, timestamp_fields)
 
     def validate_node_state_transition(self, new_state):
         """Validate Node.state transitions"""


### PR DESCRIPTION
This is to enable getting regression nodes matching attributes provided by query parameters.

- Implement `Node.translate_fields_with_operators` method to translate the parameter to `param={operator: value}
- Implement `Node.translate_timestamp_fields` method to translate ISOformat timestamp fields to `Date` object.
- Optimize `Node.translate_fields` to use above methods
- Implement `Regression.translate_fields`