### PR TITLE
T39710 Query nodes with null field values

### DIFF
--- a/api/main.py
+++ b/api/main.py
@@ -218,6 +218,7 @@ async def get_nodes(request: Request, kind: str = "node"):
     for pg_key in ['limit', 'offset']:
         query_params.pop(pg_key, None)
 
+    query_params = await translate_null_query_params(query_params)
     is_valid, msg = model.validate_params(query_params)
     if not is_valid:
         raise HTTPException(
@@ -250,6 +251,7 @@ async def get_nodes_count(request: Request, kind: str = "node"):
 
     query_params = dict(request.query_params)
 
+    query_params = await translate_null_query_params(query_params)
     is_valid, msg = model.validate_params(query_params)
     if not is_valid:
         raise HTTPException(

--- a/api/main.py
+++ b/api/main.py
@@ -174,6 +174,15 @@ def get_password_hash(password: Password):
 # -----------------------------------------------------------------------------
 # Nodes
 
+async def translate_null_query_params(query_params: dict):
+    """Translate null query parameters to None"""
+    translated = query_params.copy()
+    for key, value in query_params.items():
+        if value == 'null':
+            translated[key] = None
+    return translated
+
+
 @app.get('/node/{node_id}', response_model=Union[Regression, Node])
 async def get_node(node_id: str, kind: str = "node"):
     """Get node information from the provided node id"""

--- a/api/models.py
+++ b/api/models.py
@@ -265,6 +265,8 @@ URLs (e.g. URL to binaries or logs)'
         timestamp_fields = ('created', 'updated', 'timeout', 'holdoff')
         # Split params with `__` in key and translate timestamp fields
         for key in params.keys():
+            if translated[key] is None:
+                continue
             if key in timestamp_fields:
                 translated[key] = datetime.fromisoformat(translated[key])
             field = key.split('__')

--- a/doc/api-details.md
+++ b/doc/api-details.md
@@ -164,6 +164,17 @@ $ curl 'http://localhost:8001/nodes?name=checkout&created__gt=2022-12-06T04:59:0
 
 > **Note** In order to support comparison operators in URL request parameters, models can not contain `__` in the field name.
 
+Nodes with `null` fields can also be retrieved using the endpoint.
+For example, the below command will get all the nodes with `parent` field set to `null`:
+
+```
+$ curl 'http://localhost:8001/nodes?parent=null'
+"items":[{"_id":"63c549319fb3b62c7626e7f9","kind":"node","name":"checkout","path":["checkout"],"group":null,"revision":{"tree":"kernelci","url":"https://github.com/kernelci/linux.git","branch":"staging-mainline","commit":"1385303d0d85c68473d8901d69c7153b03a3150b","describe":"staging-mainline-20230115.1","version":{"version":6,"patchlevel":2,"sublevel":null,"extra":"-rc4-2-g1385303d0d85","name":null}},"parent":null,"state":"available","result":null,"artifacts":{"tarball":"http://172.17.0.1:8002/linux-kernelci-staging-mainline-staging-mainline-20230115.1.tar.gz"},"created":"2023-01-16T12:55:13.879000","updated":"2023-01-16T12:55:51.780000","timeout":"2023-01-16T13:55:13.877000","holdoff":"2023-01-16T13:05:51.776000"},{"_id":"63c549329fb3b62c7626e7fa","kind":"node","name":"checkout","path":["checkout"],"group":null,"revision":{"tree":"kernelci","url":"https://github.com/kernelci/linux.git","branch":"staging-next","commit":"39384a5d7e2eb2f28039a92c022aed886a675fbf","describe":"staging-next-20230116.0","version":{"version":6,"patchlevel":2,"sublevel":null,"extra":"-rc4-5011-g39384a5d7e2e","name":null}},"parent":null,"state":"available","result":null,"artifacts":{"tarball":"http://172.17.0.1:8002/linux-kernelci-staging-next-staging-next-20230116.0.tar.gz"},"created":"2023-01-16T12:55:14.706000","updated":"2023-01-16T12:56:30.886000","timeout":"2023-01-16T13:55:14.703000","holdoff":"2023-01-16T13:06:30.882000"}],"total":2,"limit":50,"offset":0}
+```
+
+Please make sure that the query parameter provided with the `null` value in the request exists in the `Node` schema. Otherwise, the API will behave unexpectedly and return all the nodes.
+
+
 ### Update a Node
 
 To update an existing node, use PUT request to `node/{node_id}` endpoint.
@@ -213,6 +224,13 @@ Same as `/nodes`, the `/count` endpoint also supports comparison operators for r
 ```
 $ curl 'http://localhost:8001/count?name=checkout&created__lt=2022-12-06T04:59:08.102000'
 3
+```
+
+To query the count of nodes with `null` attributes, use the endpoint with
+query parameters set to `null`.
+```
+$ curl 'http://localhost:8001/count?result=null'
+2
 ```
 
 ### State diagram


### PR DESCRIPTION
Fixes https://github.com/kernelci/kernelci-api/issues/205

Enable support for allowing `null` as the request query param value to `/nodes` and `/count` endpoints for GET requests.

e.g. Request to get root nodes from the database will be http://localhost:8001/nodes?parent=null

