### PR TITLE
T39784 Introduce API versioning

### DIFF
--- a/api/main.py
+++ b/api/main.py
@@ -22,6 +22,7 @@ from fastapi.security import (
     SecurityScopes
 )
 from fastapi_pagination import add_pagination
+from fastapi_versioning import VersionedFastAPI
 from bson import ObjectId, errors
 from pymongo.errors import DuplicateKeyError
 from .auth import Authentication, Token
@@ -432,3 +433,16 @@ async def put_regression(regression_id: str, regression: Regression,
     await pubsub.publish_cloudevent('regression', {'op': operation,
                                                    'id': str(obj.id)})
     return obj
+
+
+app = VersionedFastAPI(
+        app,
+        version_format='{major}',
+        prefix_format='/v{major}',
+        enable_latest=True,
+        default_version=(0, 0),
+        on_startup=[
+            pubsub_startup,
+            create_indexes,
+        ]
+    )

--- a/docker/api/requirements.txt
+++ b/docker/api/requirements.txt
@@ -8,3 +8,4 @@ python-jose[cryptography]==3.3.0
 uvicorn[standard]==0.13.4
 motor==2.5.1
 pymongo-migrate==0.11.0
+fastapi-versioning==0.10.0

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -29,6 +29,8 @@ eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.\
 eyJzdWIiOiJib2IiLCJzY29wZXMiOlsiYWRtaW4iXX0.\
 t3bAE-pHSzZaSHp7FMlImqgYvL6f_0xDUD-nQwxEm3k'
 
+API_VERSION = '/latest'
+
 
 @pytest.fixture
 def client():

--- a/test/test_count_handler.py
+++ b/test/test_count_handler.py
@@ -8,6 +8,7 @@
 """Unit test functions for KernelCI API count handler"""
 
 
+from test.conftest import API_VERSION
 from fastapi.testclient import TestClient
 from api.main import app
 
@@ -21,7 +22,7 @@ def test_count_nodes(mock_db_count, mock_init_sub_id):
     """
     mock_db_count.return_value = 10
     with TestClient(app) as client:
-        response = client.get("/count")
+        response = client.get(API_VERSION + "/count")
         print("response.json()", response.json())
         assert response.status_code == 200
         assert response.json() >= 0
@@ -36,7 +37,7 @@ def test_count_nodes_matching_attributes(mock_db_count, mock_init_sub_id):
     """
     mock_db_count.return_value = 1
     with TestClient(app) as client:
-        response = client.get("/count?name=checkout")
+        response = client.get(API_VERSION + "/count?name=checkout")
         print("response.json()", response.json())
         assert response.status_code == 200
         assert response.json() == 1

--- a/test/test_listen_handler.py
+++ b/test/test_listen_handler.py
@@ -10,7 +10,7 @@
 
 """Unit test functions for KernelCI API listen handler"""
 
-from test.conftest import BEARER_TOKEN
+from test.conftest import BEARER_TOKEN, API_VERSION
 
 from fastapi.testclient import TestClient
 
@@ -31,7 +31,7 @@ def test_listen_endpoint(mock_get_current_user,
 
     with TestClient(app) as client:
         response = client.get(
-            "/listen/1",
+            API_VERSION + "/listen/1",
             headers={
                 "Authorization": BEARER_TOKEN
             },
@@ -51,7 +51,7 @@ def test_listen_endpoint_not_found(mock_get_current_user,
     """
     with TestClient(app) as client:
         response = client.get(
-            "/listen/1",
+            API_VERSION + "/listen/1",
             headers={
                 "Authorization": BEARER_TOKEN
             },
@@ -71,7 +71,7 @@ def test_listen_endpoint_without_token(mock_get_current_user,
     """
     with TestClient(app) as client:
         response = client.get(
-            "/listen/1",
+            API_VERSION + "/listen/1",
             headers={
                 "Accept": "application/json"
             },

--- a/test/test_me_handler.py
+++ b/test/test_me_handler.py
@@ -7,7 +7,7 @@
 
 """Unit test function for KernelCI API me handler"""
 
-from test.conftest import BEARER_TOKEN
+from test.conftest import BEARER_TOKEN, API_VERSION
 
 from fastapi.testclient import TestClient
 
@@ -24,7 +24,7 @@ def test_me_endpoint(mock_get_current_user):
     """
     client = TestClient(app)
     response = client.get(
-        "/me",
+        API_VERSION + "/me",
         headers={
             "Accept": "application/json",
             "Authorization": BEARER_TOKEN

--- a/test/test_node_handler.py
+++ b/test/test_node_handler.py
@@ -12,7 +12,7 @@
 
 import json
 
-from test.conftest import BEARER_TOKEN
+from test.conftest import BEARER_TOKEN, API_VERSION
 from bson import errors
 
 from fastapi.testclient import TestClient
@@ -64,7 +64,7 @@ def test_create_node_endpoint(mock_get_current_user, mock_init_sub_id,
                 }
             }
         response = client.post(
-            "/node",
+            API_VERSION + "/node",
             headers={
                 "Accept": "application/json",
                 "Authorization": BEARER_TOKEN
@@ -153,7 +153,7 @@ def test_get_nodes_by_attributes_endpoint(mock_get_current_user,
     }
     with TestClient(app) as client:
         response = client.get(
-            "/nodes",
+            API_VERSION + "/nodes",
             params=params,
             )
         print("response.json()", response.json())
@@ -186,7 +186,7 @@ def test_get_nodes_by_attributes_endpoint_node_not_found(
     }
     with TestClient(app) as client:
         response = client.get(
-            "/nodes",
+            API_VERSION + "/nodes",
             params=params
             )
         print("response.json()", response.json())
@@ -225,7 +225,7 @@ def test_get_node_by_id_endpoint(mock_get_current_user, mock_db_find_by_id,
     mock_db_find_by_id.return_value = node_obj
 
     with TestClient(app) as client:
-        response = client.get("/node/61bda8f2eb1a63d2b7152418")
+        response = client.get(API_VERSION + "/node/61bda8f2eb1a63d2b7152418")
         print("response.json()", response.json())
         assert response.status_code == 200
         assert response.json().keys() == {
@@ -259,7 +259,7 @@ def test_get_node_by_id_endpoint_empty_response(mock_get_current_user,
     mock_db_find_by_id.return_value = None
 
     with TestClient(app) as client:
-        response = client.get("/node/61bda8f2eb1a63d2b7152419")
+        response = client.get(API_VERSION + "/node/61bda8f2eb1a63d2b7152419")
         print("response.json()", response.json())
         assert response.status_code == 200
         assert response.json() is None
@@ -337,7 +337,7 @@ def test_get_all_nodes(mock_get_current_user, mock_db_find_by_attributes,
     }
 
     with TestClient(app) as client:
-        response = client.get("/nodes")
+        response = client.get(API_VERSION + "/nodes")
         print("response.json()", response.json())
         assert response.status_code == 200
         assert len(response.json()) > 0
@@ -361,7 +361,7 @@ def test_get_all_nodes_empty_response(mock_get_current_user,
     }
 
     with TestClient(app) as client:
-        response = client.get("/nodes")
+        response = client.get(API_VERSION + "/nodes")
         print("response.json()", response.json())
         assert response.status_code == 200
         assert response.json().get('total') == 0
@@ -405,7 +405,9 @@ def test_get_root_node_endpoint(mock_db_find_by_id, mock_init_sub_id):
     mock_db_find_by_id.side_effect = [node_obj, root_node_obj]
 
     with TestClient(app) as client:
-        response = client.get("/get_root_node/61bda8f2eb1a63d2b7152418")
+        response = client.get(
+            API_VERSION + "/get_root_node/61bda8f2eb1a63d2b7152418"
+        )
         print("response.json()", response.json())
         assert response.status_code == 200
         assert response.json().keys() == {
@@ -438,7 +440,9 @@ def test_get_root_node_endpoint_node_not_found(mock_db_find_by_id,
     mock_db_find_by_id.return_value = None
 
     with TestClient(app) as client:
-        response = client.get("/get_root_node/61bda8f2eb1a63d2b7152419")
+        response = client.get(
+            API_VERSION + "/get_root_node/61bda8f2eb1a63d2b7152419"
+        )
         print("response.json()", response.json())
         assert response.status_code == 400
         assert 'detail' in response.json()
@@ -456,7 +460,9 @@ def test_get_root_node_endpoint_invalid_node_id(mock_db_find_by_id,
     mock_db_find_by_id.side_effect = errors.InvalidId
 
     with TestClient(app) as client:
-        response = client.get("/get_root_node/61bda8f2eb1a63d2b71524")
+        response = client.get(
+            API_VERSION + "/get_root_node/61bda8f2eb1a63d2b71524"
+        )
         print("response.json()", response.json())
         assert response.status_code == 400
         assert 'detail' in response.json()

--- a/test/test_root_handler.py
+++ b/test/test_root_handler.py
@@ -5,6 +5,8 @@
 
 """Unit test function for KernelCI API root handler"""
 
+from test.conftest import API_VERSION
+
 
 def test_root_endpoint(client):
     """
@@ -13,6 +15,6 @@ def test_root_endpoint(client):
         HTTP Response Code 200 OK
         JSON with 'message' key
     """
-    response = client.get("/")
+    response = client.get(API_VERSION + "/")
     assert response.status_code == 200
     assert response.json() == {"message": "KernelCI API"}

--- a/test/test_subscribe_handler.py
+++ b/test/test_subscribe_handler.py
@@ -7,7 +7,7 @@
 
 """Unit test function for KernelCI API subscribe handler"""
 
-from test.conftest import BEARER_TOKEN
+from test.conftest import BEARER_TOKEN, API_VERSION
 
 from fastapi.testclient import TestClient
 
@@ -29,7 +29,7 @@ def test_subscribe_endpoint(mock_get_current_user, mock_init_sub_id,
     with TestClient(app) as client:
         # Use context manager to trigger a startup event on the app object
         response = client.post(
-            "/subscribe/abc",
+            API_VERSION + "/subscribe/abc",
             headers={
                 "Authorization": BEARER_TOKEN
             },

--- a/test/test_token_handler.py
+++ b/test/test_token_handler.py
@@ -8,6 +8,7 @@
 
 """Unit test function for KernelCI API token handler"""
 
+from test.conftest import API_VERSION
 from fastapi.testclient import TestClient
 
 from api.main import app
@@ -28,7 +29,7 @@ def test_token_endpoint(mock_db_find_one):
     mock_db_find_one.return_value = user
     client = TestClient(app)
     response = client.post(
-        "/token",
+       API_VERSION + "/token",
         headers={
             "Accept": "application/json",
             "Content-Type": "application/x-www-form-urlencoded"
@@ -58,7 +59,7 @@ def test_token_endpoint_incorrect_password(mock_db_find_one):
 
     # Pass incorrect password
     response = client.post(
-        "/token",
+        API_VERSION + "/token",
         headers={
             "Accept": "application/json",
             "Content-Type": "application/x-www-form-urlencoded"
@@ -84,7 +85,7 @@ def test_token_endpoint_admin_user(mock_db_find_one):
     mock_db_find_one.return_value = user
     client = TestClient(app)
     response = client.post(
-        "/token",
+        API_VERSION + "/token",
         headers={
             "Accept": "application/json",
             "Content-Type": "application/x-www-form-urlencoded"

--- a/test/test_unsubscribe_handler.py
+++ b/test/test_unsubscribe_handler.py
@@ -7,7 +7,7 @@
 
 """Unit test functions for KernelCI API unsubscribe handler"""
 
-from test.conftest import BEARER_TOKEN
+from test.conftest import BEARER_TOKEN, API_VERSION
 
 from fastapi.testclient import TestClient
 
@@ -23,7 +23,7 @@ def test_unsubscribe_endpoint(mock_get_current_user,
     """
     with TestClient(app) as client:
         response = client.post(
-            "/unsubscribe/1",
+            API_VERSION + "/unsubscribe/1",
             headers={
                 "Authorization": BEARER_TOKEN
             },
@@ -41,7 +41,7 @@ def test_unsubscribe_endpoint_empty_response(mock_get_current_user,
     """
     with TestClient(app) as client:
         response = client.post(
-            "/unsubscribe/1",
+            API_VERSION + "/unsubscribe/1",
             headers={
                 "Authorization": BEARER_TOKEN
             },

--- a/test/test_user_handler.py
+++ b/test/test_user_handler.py
@@ -9,7 +9,7 @@
 
 import json
 
-from test.conftest import ADMIN_BEARER_TOKEN, BEARER_TOKEN
+from test.conftest import ADMIN_BEARER_TOKEN, BEARER_TOKEN, API_VERSION
 
 from fastapi.testclient import TestClient
 
@@ -33,7 +33,7 @@ HR5UHMdMFQeOe1eD4oXaP08oW7ogYqyiNziZYNdUHs8i", active=True)
 
     with TestClient(app) as client:
         response = client.post(
-            "/user/test",
+            API_VERSION + "/user/test",
             headers={
                 "Accept": "application/json",
                 "Authorization": ADMIN_BEARER_TOKEN
@@ -62,7 +62,7 @@ HR5UHMdMFQeOe1eD4oXaP08oW7ogYqyiNziZYNdUHs8i", active=True, is_admin=True)
 
     with TestClient(app) as client:
         response = client.post(
-            "/user/test_admin?is_admin=1",
+            API_VERSION + "/user/test_admin?is_admin=1",
             headers={
                 "Accept": "application/json",
                 "Authorization": ADMIN_BEARER_TOKEN
@@ -88,7 +88,7 @@ def test_create_user_endpoint_negative(mock_init_sub_id, mock_get_current_user,
 
     with TestClient(app) as client:
         response = client.post(
-            "/user/test",
+            API_VERSION + "/user/test",
             headers={
                 "Accept": "application/json",
                 "Authorization": BEARER_TOKEN


### PR DESCRIPTION
Fixes https://github.com/kernelci/kernelci-api/issues/208

Integrate `fastapi-versioning` module for versioning.
Use versioned FastAPI instance for API versioning by using `VersionedFastAPI`.
Provide version format (only major numbers at the moment) and prefix (i.e. `/v`) to the constructor.
Also, provide start-up handlers and default version i.e `v0`. The latest version can be called using `/latest` prefix.
Sample URL to get all the nodes: `https://API_SERVER_URL:PORT/v0/nodes`.