### PR TITLE
T40027 Introduce end-to-end testing for API

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,48 @@
+# This is a basic workflow to help you get started with Actions
+
+name: test
+
+# Controls when the workflow will run
+on:
+  # Triggers the workflow on push or pull request events but only for the
+  # main branch
+  push:
+    branches: [  main ]
+  pull_request:
+    branches: [ main ]
+
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+jobs:
+  test:
+    runs-on: ubuntu-20.04
+
+    strategy:
+      matrix:
+        python-version: ['3.10'] # Only supported one at the moment
+
+    steps:
+
+      - name: Check out source code
+        uses: actions/checkout@v2
+
+      - name: Export environment variables
+        run: |
+          echo "SECRET_KEY=$(openssl rand -hex 32)" > .env
+
+      - name: Build docker images
+        run: docker-compose -f test-docker-compose.yaml build
+
+      - name: Run API containers
+        run: |
+          docker-compose -f test-docker-compose.yaml up -d api db redis storage ssh
+
+      - name: Run test container
+        run: |
+          docker-compose -f test-docker-compose.yaml up --exit-code-from test test
+
+      - name: Stop docker containers
+        if: always()
+        run: |
+          docker-compose -f test-docker-compose.yaml down

--- a/docker/test/Dockerfile
+++ b/docker/test/Dockerfile
@@ -1,0 +1,25 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+#
+# Copyright (C) 2023 Collabora Limited
+# Author: Jeny Sadadia <jeny.sadadia@collabora.com>
+
+FROM python:3.10
+MAINTAINER "KernelCI TSC" <kernelci-tsc@groups.io>
+
+# Upgrade pip3 - never mind the warning about running this as root
+RUN pip3 install --upgrade pip
+
+# Create kernelci user
+RUN useradd kernelci -u 1000 -d /home/kernelci -s /bin/bash
+RUN mkdir -p /home/kernelci
+RUN chown kernelci: /home/kernelci
+USER kernelci
+ENV PATH=$PATH:/home/kernelci/.local/bin
+WORKDIR /home/kernelci
+
+# Install requirements
+COPY requirements*.txt /home/kernelci/
+ARG REQUIREMENTS=requirements.txt
+RUN pip install --requirement ${REQUIREMENTS}
+
+CMD ["pytest", "-v", "e2e_tests"]

--- a/docker/test/requirements.txt
+++ b/docker/test/requirements.txt
@@ -12,3 +12,4 @@ pytest==6.2.5
 pytest-asyncio==0.16.0
 httpx==0.23.3
 pytest-dependency==0.5.1
+pytest-order==1.0.1

--- a/docker/test/requirements.txt
+++ b/docker/test/requirements.txt
@@ -1,0 +1,13 @@
+aioredis[hiredis]==2.0.0
+cloudevents==1.2.0
+fastapi[all]==0.68.1
+fastapi-pagination==0.9.3
+passlib==1.7.4
+pydantic==1.8.2
+python-jose[cryptography]==3.3.0
+uvicorn[standard]==0.13.4
+motor==2.5.1
+fastapi-versioning==0.10.0
+pytest==6.2.5
+pytest-asyncio==0.16.0
+httpx==0.23.3

--- a/docker/test/requirements.txt
+++ b/docker/test/requirements.txt
@@ -11,3 +11,4 @@ fastapi-versioning==0.10.0
 pytest==6.2.5
 pytest-asyncio==0.16.0
 httpx==0.23.3
+pytest-dependency==0.5.1

--- a/e2e_tests/conftest.py
+++ b/e2e_tests/conftest.py
@@ -1,0 +1,22 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+#
+# Copyright (C) 2023 Collabora Limited
+# Author: Jeny Sadadia <jeny.sadadia@collabora.com>
+
+
+"""pytest fixtures for KernelCI API end-to-end tests"""
+
+import pytest
+
+from fastapi.testclient import TestClient
+
+from api.main import app
+
+BASE_URL = 'http://api:8000/latest/'
+
+
+@pytest.fixture(scope='session')
+def test_client():
+    """Fixture to get FastAPI Test client instance"""
+    with TestClient(app=app, base_url=BASE_URL) as client:
+        yield client

--- a/e2e_tests/listen_handler.py
+++ b/e2e_tests/listen_handler.py
@@ -1,0 +1,29 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+#
+# Copyright (C) 2023 Collabora Limited
+# Author: Jeny Sadadia <jeny.sadadia@collabora.com>
+
+
+"""Helper function for KernelCI API listen handler"""
+
+import pytest
+import asyncio
+
+
+def create_listen_task(test_async_client, subscription_id):
+    """
+    Create an asyncio Task to listen to pubsub events on node channel using
+    API endpoint `/listen`.
+    Returns the task instance.
+    """
+    listen_path = '/'.join(['listen', str(subscription_id)])
+    task_listen = asyncio.create_task(
+        test_async_client.get(
+            listen_path,
+            headers={
+                "Accept": "application/json",
+                "Authorization": f"Bearer {pytest.BEARER_TOKEN}"
+            },
+        )
+    )
+    return task_listen

--- a/e2e_tests/test_count_handler.py
+++ b/e2e_tests/test_count_handler.py
@@ -1,0 +1,42 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+#
+# Copyright (C) 2023 Collabora Limited
+# Author: Jeny Sadadia <jeny.sadadia@collabora.com>
+
+
+"""End-to-end test functions for KernelCI API count handler"""
+
+
+import pytest
+
+
+@pytest.mark.dependency(
+    depends=[
+        'e2e_tests/test_pipeline.py::test_node_pipeline'],
+    scope='session')
+def test_count_nodes(test_client):
+    """
+    Test Case : Test KernelCI API GET /count endpoint
+    Expected Result :
+        HTTP Response Code 200 OK
+        Total number of nodes available
+    """
+    response = test_client.get("count")
+    assert response.status_code == 200
+    assert response.json() >= 0
+
+
+@pytest.mark.dependency(
+    depends=[
+        'e2e_tests/test_pipeline.py::test_node_pipeline'],
+    scope='session')
+def test_count_nodes_matching_attributes(test_client):
+    """
+    Test Case : Test KernelCI API GET /count endpoint with attributes
+    Expected Result :
+        HTTP Response Code 200 OK
+        Number of nodes matching attributes
+    """
+    response = test_client.get("count?name=checkout")
+    assert response.status_code == 200
+    assert response.json() >= 0

--- a/e2e_tests/test_node_handler.py
+++ b/e2e_tests/test_node_handler.py
@@ -1,0 +1,140 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+#
+# Copyright (C) 2023 Collabora Limited
+# Author: Jeny Sadadia <jeny.sadadia@collabora.com>
+
+
+"""Test functions for KernelCI API node handler"""
+
+import json
+import pytest
+
+
+async def create_node(test_async_client, node):
+    """
+    Test Case : Test KernelCI API POST '/node' endpoint
+    Expected Result :
+        HTTP Response Code 200 OK
+        JSON with created Node object attributes
+    """
+    response = await test_async_client.post(
+        "node",
+        headers={
+            "Accept": "application/json",
+            "Authorization": f"Bearer {pytest.BEARER_TOKEN}"
+        },
+        data=json.dumps(node)
+        )
+    assert response.status_code == 200
+    assert response.json().keys() == {
+            '_id',
+            'artifacts',
+            'created',
+            'group',
+            'holdoff',
+            'kind',
+            'name',
+            'path',
+            'parent',
+            'result',
+            'revision',
+            'state',
+            'timeout',
+            'updated',
+        }
+    return response
+
+
+async def get_node_by_id(test_async_client, node_id):
+    """
+    Test Case : Test KernelCI API GET /node/{node_id} endpoint
+    Expected Result :
+        HTTP Response Code 200 OK
+        JSON with Node object attributes
+    """
+    response = await test_async_client.get(
+        f"node/{node_id}",
+        headers={
+            "Accept": "application/json",
+            "Authorization": f"Bearer {pytest.BEARER_TOKEN}"
+        },
+    )
+    assert response.status_code == 200
+    assert response.json().keys() == {
+            '_id',
+            'artifacts',
+            'created',
+            'group',
+            'holdoff',
+            'kind',
+            'name',
+            'path',
+            'parent',
+            'result',
+            'revision',
+            'state',
+            'timeout',
+            'updated',
+        }
+    return response
+
+
+async def get_node_by_attribute(test_async_client, params):
+    """
+    Test Case : Test KernelCI API GET /nodes matching query parameters
+    Expected Result :
+        HTTP Response Code 200 OK
+        Returns dictionary with matching Node objects, total number of nodes
+        returned along with limit and offset values
+    """
+    response = await test_async_client.get(
+        "nodes",
+        params=params,
+        headers={
+            "Accept": "application/json",
+            "Authorization": f"Bearer {pytest.BEARER_TOKEN}"
+        },
+    )
+    assert response.status_code == 200
+    assert response.json().keys() == {
+            'items',
+            'total',
+            'limit',
+            'offset',
+        }
+    assert response.json()['total'] >= 0
+    return response
+
+
+async def update_node(test_async_client, node):
+    """
+    Test Case : Test KernelCI API PUT /node/{node_id} endpoint
+    Expected Result :
+        HTTP Response Code 200 OK
+        JSON with updated Node object
+    """
+    response = await test_async_client.put(
+        f"node/{node['_id']}",
+        headers={
+            "Accept": "application/json",
+            "Authorization": f"Bearer {pytest.BEARER_TOKEN}"
+        },
+        data=json.dumps(node)
+    )
+    assert response.status_code == 200
+    assert response.json().keys() == {
+            '_id',
+            'artifacts',
+            'created',
+            'group',
+            'holdoff',
+            'kind',
+            'name',
+            'path',
+            'parent',
+            'result',
+            'revision',
+            'state',
+            'timeout',
+            'updated',
+        }

--- a/e2e_tests/test_pipeline.py
+++ b/e2e_tests/test_pipeline.py
@@ -1,0 +1,82 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+#
+# Copyright (C) 2023 Collabora Limited
+# Author: Jeny Sadadia <jeny.sadadia@collabora.com>
+
+
+"""Run test pipeline for KernelCI API"""
+
+import pytest
+from cloudevents.http import from_json
+
+from .listen_handler import create_listen_task
+from .test_node_handler import create_node, get_node_by_id, update_node
+
+
+@pytest.mark.dependency(
+    depends=[
+        'e2e_tests/test_subscribe_handler.py::test_subscribe_node_channel'],
+    scope='session')
+@pytest.mark.order(4)
+@pytest.mark.asyncio
+async def test_node_pipeline(test_async_client):
+    """
+    The function is used to run a test node pipeline.
+    Pipeline flow:
+
+    The pipeline will create asyncio 'Task' instance to run it in the
+    background to receive pubsub events using '/listen' endpoint.
+    A sample 'checkout' node will be created using POST '/node' request.
+    The 'created' event will be received from the listener task.
+    The GET '/node/{node_id}' will be sent using node id from event data to
+    get newly created node object.
+    Again, a task for listening to pubsub will be created to receive events
+    on node channel.
+    The PUT '/node' request will update the node with modified 'node.state'
+    field. At the end, the listener task will receive node 'updated' event.
+    """
+
+    # Create Task to listen pubsub event on 'node' channel
+    task_listen = create_listen_task(test_async_client,
+                                     pytest.node_channel_subscription_id)
+
+    # Create a node
+    node = {
+        "name": "checkout",
+        "path": ["checkout"],
+        "revision": {
+            "tree": "mainline",
+            "url": "https://git.kernel.org/pub/scm/linux/kernel/git/"
+                    "torvalds/linux.git",
+            "branch": "master",
+            "commit": "2a987e65025e2b79c6d453b78cb5985ac6e5eb26",
+            "describe": "v5.16-rc4-31-g2a987e65025e"
+        }
+    }
+    response = await create_node(test_async_client, node)
+
+    # Get result of pubsub event listen task
+    await task_listen
+    event_data = from_json(task_listen.result().json().get('data')).data
+    assert ('op', 'id') == tuple(event_data.keys())
+    assert event_data.get('op') == 'created'
+    assert event_data.get('id') == response.json()['_id']
+
+    # Get node id from event data and get created node by id
+    response = await get_node_by_id(test_async_client, event_data.get('id'))
+    node = response.json()
+
+    # Create Task to listen 'updated' event on 'node' channel
+    task_listen = create_listen_task(test_async_client,
+                                     pytest.node_channel_subscription_id)
+
+    # Update node.state
+    node.update({"state": "done"})
+    # Update the node
+    await update_node(test_async_client, node)
+
+    # Get result of pubsub event listen task
+    await task_listen
+    event_data = from_json(task_listen.result().json().get('data')).data
+    assert ('op', 'id') == tuple(event_data.keys())
+    assert event_data.get('op') == 'updated'

--- a/e2e_tests/test_pubsub_handler.py
+++ b/e2e_tests/test_pubsub_handler.py
@@ -1,0 +1,52 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+#
+# Copyright (C) 2023 Collabora Limited
+# Author: Jeny Sadadia <jeny.sadadia@collabora.com>
+
+
+"""End-to-end test function for KernelCI API pubsub handler"""
+
+import pytest
+from cloudevents.http import CloudEvent, to_structured, from_json
+
+from .listen_handler import create_listen_task
+
+
+@pytest.mark.asyncio
+async def test_pubsub_handler(test_async_client):
+    """
+    Test KernelCI API Pub/Sub.
+    Publish event using '/publish' endpoint on 'test_channel'.
+    Use pubsub listener task to verify published event message.
+    """
+    # Create Task to listen pubsub event on 'test_channel' channel
+    task_listen = create_listen_task(test_async_client,
+                                     pytest.test_channel_subscription_id)
+
+    # Created and publish CloudEvent
+    attributes = {
+        "type": "api.kernelci.org",
+        "source": "https://api.kernelci.org/",
+    }
+    data = {"message": "Test message"}
+    event = CloudEvent(attributes, data)
+    headers, body = to_structured(event)
+    headers['Authorization'] = f"Bearer {pytest.BEARER_TOKEN}"
+    response = await test_async_client.post(
+        "publish/test_channel",
+        headers=headers,
+        data=body
+        )
+    assert response.status_code == 200
+
+    # Get result of pubsub event listener
+    await task_listen
+    assert task_listen.result().json().keys() == {
+        'channel',
+        'data',
+        'pattern',
+        'type',
+    }
+    event_data = from_json(task_listen.result().json().get('data')).data
+    assert ('message',) == tuple(event_data.keys())
+    assert event_data.get('message') == 'Test message'

--- a/e2e_tests/test_regression_handler.py
+++ b/e2e_tests/test_regression_handler.py
@@ -1,0 +1,113 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+#
+# Copyright (C) 2023 Collabora Limited
+# Author: Jeny Sadadia <jeny.sadadia@collabora.com>
+
+
+"""End-to-end test function for KernelCI API regression handler"""
+
+import json
+import pytest
+
+from .test_node_handler import create_node, get_node_by_attribute
+
+
+async def create_regression(test_async_client, regression_node):
+    """
+    Test Case : Test KernelCI API POST '/regression' endpoint
+    Expected Result :
+        HTTP Response Code 200 OK
+        JSON with created Regression object attributes
+    """
+    response = await test_async_client.post(
+        "regression",
+        headers={
+            "Accept": "application/json",
+            "Authorization": f"Bearer {pytest.BEARER_TOKEN}"
+        },
+        data=json.dumps(regression_node)
+        )
+    assert response.status_code == 200
+    assert response.json().keys() == {
+            '_id',
+            'artifacts',
+            'created',
+            'group',
+            'holdoff',
+            'kind',
+            'name',
+            'path',
+            'parent',
+            'result',
+            'revision',
+            'regression_data',
+            'state',
+            'timeout',
+            'updated',
+        }
+
+
+@pytest.mark.dependency(
+    depends=[
+        "e2e_tests/test_pipeline.py::test_node_pipeline"],
+    scope="session")
+@pytest.mark.asyncio
+async def test_regression_handler(test_async_client):
+    """
+    The function is used to test creation of a regression object.
+
+    First, it will get 'checkout' node. After getting the parent node,
+    two 'kver' child nodes having different name and result ('pass' and
+    'fail') will be created. Based on child nodes, a regression
+    node will be generated and added to database using 'create_regression'
+    method.
+    """
+    # Get "checkout" node
+    response = await get_node_by_attribute(
+        test_async_client, {"name": "checkout"}
+    )
+    checkout_node = response.json()["items"][0]
+
+    # Create a 'kver' passed node
+    passed_node = {
+        "name": "passed_kver",
+        "path": ["checkout", "kver"],
+        "group": "kver",
+        "parent": checkout_node["_id"],
+        "revision": {
+            "tree": "mainline",
+            "url": "https://git.kernel.org/pub/scm/linux/kernel/git/"
+                    "torvalds/linux.git",
+            "branch": "master",
+            "commit": "2a987e65025e2b79c6d453b78cb5985ac6e5eb26",
+            "describe": "v5.16-rc4-31-g2a987e65025e",
+        },
+        "state": "done",
+        "result": "pass",
+    }
+
+    passed_node_obj = (
+        await create_node(test_async_client, passed_node)
+    ).json()
+
+    # Create a 'kver' failed node
+    failed_node = passed_node.copy()
+    failed_node["name"] = "failed_kver"
+    failed_node["result"] = "fail"
+
+    failed_node_obj = (
+        await create_node(test_async_client, failed_node)
+    ).json()
+
+    # Create a "kver" regression node
+    regression_fields = [
+            'group', 'name', 'path', 'revision', 'result', 'state',
+        ]
+    regression_node = {
+        field: failed_node_obj[field]
+        for field in regression_fields
+    }
+
+    regression_node["parent"] = failed_node_obj["_id"]
+    regression_node["regression_data"] = [failed_node_obj, passed_node_obj]
+    await create_regression(test_async_client, regression_node)

--- a/e2e_tests/test_root_handler.py
+++ b/e2e_tests/test_root_handler.py
@@ -1,0 +1,13 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+#
+# Copyright (C) 2023 Collabora Limited
+# Author: Jeny Sadadia <jeny.sadadia@collabora.com>
+
+"""End-to-end test functions for KernelCI API root handler"""
+
+
+def test_root_endpoint(test_client):
+    """Test root handler"""
+    response = test_client.get("/latest")
+    assert response.status_code == 200
+    assert response.json() == {"message": "KernelCI API"}

--- a/e2e_tests/test_subscribe_handler.py
+++ b/e2e_tests/test_subscribe_handler.py
@@ -1,0 +1,55 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+#
+# Copyright (C) 2023 Collabora Limited
+# Author: Jeny Sadadia <jeny.sadadia@collabora.com>
+
+
+"""End-to-end test functions for KernelCI API subscribe handler"""
+
+import pytest
+
+
+@pytest.mark.dependency(
+    depends=['e2e_tests/test_user_creation.py::test_create_regular_user'],
+    scope='session')
+@pytest.mark.order(3)
+def test_subscribe_node_channel(test_client):
+    """
+    Test Case : Test KernelCI API '/subscribe' endpoint with 'node' channel
+    Expected Result :
+        HTTP Response Code 200 OK
+        JSON with subscription 'id' and 'channel' keys
+    """
+    response = test_client.post(
+        "subscribe/node",
+        headers={
+            "Authorization": f"Bearer {pytest.BEARER_TOKEN}"
+        },
+    )
+    pytest.node_channel_subscription_id = response.json()['id']
+    assert response.status_code == 200
+    assert ('id', 'channel') == tuple(response.json().keys())
+    assert response.json().get('channel') == 'node'
+
+
+@pytest.mark.dependency(
+    depends=['e2e_tests/test_user_creation.py::test_create_regular_user'],
+    scope='session')
+@pytest.mark.order(3)
+def test_subscribe_test_channel(test_client):
+    """
+    Test Case : Test KernelCI API '/subscribe' endpoint with 'test_channel'
+    Expected Result :
+        HTTP Response Code 200 OK
+        JSON with subscription 'id' and 'channel' keys
+    """
+    response = test_client.post(
+        "subscribe/test_channel",
+        headers={
+            "Authorization": f"Bearer {pytest.BEARER_TOKEN}"
+        },
+    )
+    pytest.test_channel_subscription_id = response.json()['id']
+    assert response.status_code == 200
+    assert ('id', 'channel') == tuple(response.json().keys())
+    assert response.json().get('channel') == 'test_channel'

--- a/e2e_tests/test_unsubscribe_handler.py
+++ b/e2e_tests/test_unsubscribe_handler.py
@@ -1,0 +1,49 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+#
+# Copyright (C) 2023 Collabora Limited
+# Author: Jeny Sadadia <jeny.sadadia@collabora.com>
+
+
+"""End-to-end test functions for KernelCI API unsubscribe handler"""
+
+import pytest
+
+
+@pytest.mark.dependency(
+    depends=[
+        'e2e_tests/test_subscribe_handler.py::test_subscribe_node_channel'],
+    scope='session')
+@pytest.mark.order("last")
+def test_unsubscribe_node_channel(test_client):
+    """
+    Test Case : Test KernelCI API '/unsubscribe' endpoint with 'node' channel
+    Expected Result :
+        HTTP Response Code 200 OK
+    """
+    response = test_client.post(
+        f"unsubscribe/{pytest.node_channel_subscription_id}",
+        headers={
+            "Authorization": f"Bearer {pytest.BEARER_TOKEN}"
+        },
+    )
+    assert response.status_code == 200
+
+
+@pytest.mark.dependency(
+    depends=[
+        'e2e_tests/test_subscribe_handler.py::test_subscribe_test_channel'],
+    scope='session')
+@pytest.mark.order("last")
+def test_unsubscribe_test_channel(test_client):
+    """
+    Test Case : Test KernelCI API '/unsubscribe' endpoint with 'test_channel'
+    Expected Result :
+        HTTP Response Code 200 OK
+    """
+    response = test_client.post(
+        f"unsubscribe/{pytest.test_channel_subscription_id}",
+        headers={
+            "Authorization": f"Bearer {pytest.BEARER_TOKEN}"
+        },
+    )
+    assert response.status_code == 200

--- a/e2e_tests/test_user_creation.py
+++ b/e2e_tests/test_user_creation.py
@@ -14,6 +14,7 @@ from e2e_tests.conftest import db_create
 
 
 @pytest.mark.dependency()
+@pytest.mark.order(1)
 @pytest.mark.asyncio
 async def test_create_admin_user(test_async_client):
     """
@@ -59,6 +60,7 @@ async def test_create_admin_user(test_async_client):
 
 
 @pytest.mark.dependency(depends=["test_create_admin_user"])
+@pytest.mark.order(2)
 @pytest.mark.asyncio
 async def test_create_regular_user(test_async_client):
     """

--- a/e2e_tests/test_user_creation.py
+++ b/e2e_tests/test_user_creation.py
@@ -1,0 +1,139 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+#
+# Copyright (C) 2023 Collabora Limited
+# Author: Jeny Sadadia <jeny.sadadia@collabora.com>
+
+"""End-to-end test functions for KernelCI API user creation"""
+
+import json
+import pytest
+
+from api.models import User
+from api.db import Database
+from e2e_tests.conftest import db_create
+
+
+@pytest.mark.dependency()
+@pytest.mark.asyncio
+async def test_create_admin_user(test_async_client):
+    """
+    Test Case : Get hashed password using '/hash' endpoint to create an admin
+    user. Create the admin user using database create method.
+    Request authentication token using '/token' endpoint for the user and
+    store it in pytest global variable 'ADMIN_BEARER_TOKEN'.
+    """
+    username = 'admin'
+    password = 'test'
+    response = await test_async_client.post(
+        "hash",
+        data=json.dumps({'password': password})
+    )
+    hashed_password = response.json()
+    assert response.status_code == 200
+
+    obj = await db_create(
+        Database.COLLECTIONS[User],
+        User(
+            username=username,
+            hashed_password=hashed_password,
+            is_admin=1
+        ))
+    assert obj is not None
+
+    response = await test_async_client.post(
+        "token",
+        headers={
+            "Accept": "application/json",
+            "Content-Type": "application/x-www-form-urlencoded"
+        },
+        data={
+            'username': username, 'password': password, 'scope': 'admin users'
+        }
+    )
+    assert response.status_code == 200
+    assert response.json().keys() == {
+        'access_token',
+        'token_type',
+    }
+    pytest.ADMIN_BEARER_TOKEN = response.json()['access_token']
+
+
+@pytest.mark.dependency(depends=["test_create_admin_user"])
+@pytest.mark.asyncio
+async def test_create_regular_user(test_async_client):
+    """
+    Test Case : Test KernelCI API '/user' endpoint to create regular user
+    when requested with admin user's bearer token. Request '/token' endpoint
+    for the user and store it in pytest global variable 'BEARER_TOKEN'.
+    """
+    username = 'test_user'
+    password = 'test'
+    response = await test_async_client.post(
+        f"user/{username}",
+        headers={
+                "Accept": "application/json",
+                "Authorization": f"Bearer {pytest.ADMIN_BEARER_TOKEN}"
+            },
+        data=json.dumps({'password': password})
+    )
+    assert response.status_code == 200
+    assert ('_id', 'username', 'hashed_password', 'active',
+            'is_admin') == tuple(response.json().keys())
+
+    response = await test_async_client.post(
+        "token",
+        headers={
+            "Accept": "application/json",
+            "Content-Type": "application/x-www-form-urlencoded"
+        },
+        data={'username': username, 'password': password}
+    )
+    assert response.status_code == 200
+    assert response.json().keys() == {
+        'access_token',
+        'token_type',
+    }
+    pytest.BEARER_TOKEN = response.json()['access_token']
+
+
+@pytest.mark.dependency(depends=["test_create_regular_user"])
+def test_me_endpoint(test_client):
+    """
+    Test Case : Test KernelCI API /me endpoint
+    Expected Result :
+        HTTP Response Code 200 OK
+        JSON with '_id', 'username', 'hashed_password'
+        and 'active' keys
+    """
+    response = test_client.get(
+        "me",
+        headers={
+            "Accept": "application/json",
+            "Authorization": f"Bearer {pytest.BEARER_TOKEN}"
+        },
+    )
+    assert response.status_code == 200
+    assert ('_id', 'username', 'hashed_password', 'active',
+            'is_admin') == tuple(response.json().keys())
+    assert response.json()['username'] == 'test_user'
+
+
+@pytest.mark.dependency(depends=["test_create_regular_user"])
+def test_create_user_negative(test_client):
+    """
+    Test Case : Test KernelCI API /user endpoint when requested
+    with regular user's bearer token.
+    Expected Result :
+        HTTP Response Code 401 Unauthorized
+        JSON with 'detail' key denoting 'Access denied' error
+    """
+    response = test_client.post(
+        "user/test",
+        headers={
+                "Accept": "application/json",
+                "Authorization": f"Bearer {pytest.BEARER_TOKEN}"
+            },
+        data=json.dumps({'password': 'test'})
+    )
+    assert response.status_code == 401
+    assert response.json() == {'detail': 'Access denied'}

--- a/run_e2e_tests.sh
+++ b/run_e2e_tests.sh
@@ -1,0 +1,13 @@
+#!/bin/sh
+#
+# SPDX-License-Identifier: LGPL-2.1-or-later
+#
+# Copyright (C) 2023 Collabora Limited
+# Author: Jeny Sadadia <jeny.sadadia@collabora.com>
+
+# Script for running API end-to-end tests
+
+docker-compose -f test-docker-compose.yaml build
+docker-compose -f test-docker-compose.yaml up -d api db redis storage ssh
+docker-compose -f test-docker-compose.yaml up test
+docker-compose -f test-docker-compose.yaml down

--- a/test-docker-compose.yaml
+++ b/test-docker-compose.yaml
@@ -1,0 +1,60 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+#
+# Copyright (C) 2023 Collabora Limited
+# Author: Jeny Sadadia <jeny.sadadia@collabora.com>
+
+version: '3'
+services:
+
+  api:
+    container_name: 'test-kernelci-api'
+    build:
+      context: 'docker/api'
+      args:
+        - REQUIREMENTS=${REQUIREMENTS:-requirements.txt}
+    volumes:
+      - './api:/home/kernelci/api'
+    ports:
+      - '${API_HOST_PORT:-8001}:8000'
+    env_file:
+      - '.env'
+
+  db:
+    container_name: 'test-kernelci-api-db'
+    image: 'mongo:5.0'
+
+  redis:
+    container_name: 'test-kernelci-api-redis'
+    image: 'redis:6.2'
+    volumes:
+      - './docker/redis/data:/data'
+
+  storage:
+    container_name: 'test-kernelci-api-storage'
+    image: 'nginx:1.21.3'
+    volumes:
+      - './docker/storage/data:/usr/share/nginx/html'
+    ports:
+      - ${STORAGE_HOST_PORT:-8002}:80
+
+  ssh:
+    container_name: 'test-kernelci-api-ssh'
+    build:
+      context: 'docker/ssh'
+    volumes:
+      - './docker/storage/data:/home/kernelci/data'
+      - './docker/ssh/user-data:/home/kernelci/.ssh'
+    ports:
+      - '${SSH_HOST_PORT:-8022}:22'
+
+  test:
+    container_name: 'kernelci-api-e2e-tests'
+    build:
+      context: 'docker/test'
+    volumes:
+      - './api:/home/kernelci/api'
+      - './e2e_tests:/home/kernelci/e2e_tests'
+    depends_on:
+      - api
+    env_file:
+      - '.env'


### PR DESCRIPTION
Fixes https://github.com/kernelci/kernelci-api/issues/199

Added `test-docker-compose.yaml` to introduce `test` service.
The service will run tests from `e2e_tests` package.
Added below tests:
- Test API root handler
- Test admin user creation and get access token
- Test regular user creation using admin bearer token
- Negative test for regular user creation
- Test for subscribe handler
- Test for unsubscribe handler
- Add a test pipeline for node handler with pubsub event listener
- Test for count handler
- Test for regression handler

Also, added `test.yaml` in github workflows to run tests within a test environment created by `test-docker-compose.yaml`.