### PR TITLE
Revert "api.models: implement `Node.validate_parent`"

### DIFF
--- a/api/main.py
+++ b/api/main.py
@@ -284,7 +284,6 @@ async def post_node(node: Node, token: str = Depends(get_user)):
                 status_code=status.HTTP_404_NOT_FOUND,
                 detail=f"Parent not found with id: {node.parent}"
             )
-        parent.validate_parent()
     obj = await db.create(node)
     operation = 'created'
     await pubsub.publish_cloudevent('node', {'op': operation,

--- a/api/models.py
+++ b/api/models.py
@@ -322,12 +322,6 @@ URLs (e.g. URL to binaries or logs)'
             return False, f"Transition not allowed with state: {new_state}"
         return True, "Transition validated successfully"
 
-    def validate_parent(self):
-        """Validate the parent node's state before creating child nodes"""
-        if self.state != 'available':
-            raise ValueError(f"The node is unavailable to create child node: \
-{self.id}")
-
 
 class Hierarchy(BaseModel):
     """Hierarchy of nodes with child nodes"""


### PR DESCRIPTION
This reverts commit b0fb415558a8668e037e753dbcca8a1787298790.

Drop the validation that a parent node needs to be in the "available" state for adding child nodes.  This is making things more complicated during development and it's not entirely clear yet whether this should be enforced in production either.

Also drop the call to validate_parent() from api.main.

Signed-off-by: Guillaume Tucker <guillaume.tucker@collabora.com>