### PR TITLE
T40660 workflows: enable python-lint-annotate

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -59,3 +59,23 @@ jobs:
       - name: Run pytest
         run: |
           pytest -v test/
+
+  lint:
+    runs-on: ubuntu-22.04
+    name: Lint
+
+    steps:
+      - name: Check out source code
+        uses: actions/checkout@v3
+
+      - name: Run linter annotations
+        uses: marian-code/python-lint-annotate@v3
+        with:
+          python-root-list: "./test/* ./api/*"
+          use-black: false
+          use-flake8: false
+          use-isort: false
+          use-mypy: false
+          use-pycodestyle: true
+          use-pydocstyle: false
+          use-vulture: false

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -85,3 +85,4 @@ jobs:
           use-pycodestyle: true
           use-pydocstyle: false
           use-vulture: false
+          python-version: "3.10"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -47,7 +47,7 @@ jobs:
         run: |
           pylint api.auth
           pylint api.db
-          pylint -d R0903 api.models
+          pylint api.models
           pylint api.pubsub
           pylint test
           pylint api.main

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -75,6 +75,17 @@ jobs:
           echo "CHANGED_FILES=$(echo $(git diff --name-only ${{ github.event.pull_request.base.sha }}..${{ github.event.pull_request.head.sha }} -- | grep \.py))" >> $GITHUB_ENV
 
       - if: env.CHANGED_FILES
+        name: Set up Python
+        uses: actions/setup-python@master
+        with:
+          python-version: "3.10"
+
+      - if: env.CHANGED_FILES
+        name: Install Python packages
+        run: |
+          pip install -r docker/api/requirements-dev.txt
+
+      - if: env.CHANGED_FILES
         uses: marian-code/python-lint-annotate@v3
         with:
           python-root-list: ${{ env.CHANGED_FILES }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -67,11 +67,17 @@ jobs:
     steps:
       - name: Check out source code
         uses: actions/checkout@v3
+        with:
+          fetch-depth: 32  # This is necessary to get the commits
 
-      - name: Run linter annotations
+      - name: Get changed python files between base and head
+        run: >
+          echo "CHANGED_FILES=$(echo $(git diff --name-only ${{ github.event.pull_request.base.sha }}..${{ github.event.pull_request.head.sha }} -- | grep \.py))" >> $GITHUB_ENV
+
+      - if: env.CHANGED_FILES
         uses: marian-code/python-lint-annotate@v3
         with:
-          python-root-list: "./test/* ./api/*"
+          python-root-list: ${{ env.CHANGED_FILES }}
           use-black: false
           use-flake8: false
           use-isort: false

--- a/api/models.py
+++ b/api/models.py
@@ -4,6 +4,10 @@
 # Author: Guillaume Tucker <guillaume.tucker@collabora.com>
 # Author: Jeny Sadadia <jeny.sadadia@collabora.com>
 
+# Disable below flag as some models are just for storing the data and do not
+# need methods
+# pylint: disable=too-few-public-methods
+
 """KernelCI API model definitions"""
 
 from datetime import datetime, timedelta


### PR DESCRIPTION
Fixes https://github.com/kernelci/kernelci-api/issues/212

Add a job 'lint' using python-lint-annotate to run pylint with GitHub inline annotations.

Tested with https://github.com/kernelci/kernelci-api/pull/217