### PR TITLE
T40780 Split requirements from `requirements-dev.txt` file

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -83,7 +83,7 @@ jobs:
       - if: env.CHANGED_FILES
         name: Install Python packages
         run: |
-          pip install -r docker/api/requirements-dev.txt
+          pip install -r docker/api/requirements-tests.txt
 
       - if: env.CHANGED_FILES
         uses: marian-code/python-lint-annotate@v3

--- a/docker/api/requirements-dev.txt
+++ b/docker/api/requirements-dev.txt
@@ -1,7 +1,3 @@
--r requirements.txt
-fakeredis==1.7.0
+-r requirements-tests.txt
 pycodestyle==2.8.0
 pylint==2.12.2
-pytest==6.2.5
-pytest-asyncio==0.16.0
-pytest-mock==3.6.1

--- a/docker/api/requirements-tests.txt
+++ b/docker/api/requirements-tests.txt
@@ -1,0 +1,5 @@
+-r requirements.txt
+fakeredis==1.7.0
+pytest==6.2.5
+pytest-asyncio==0.16.0
+pytest-mock==3.6.1


### PR DESCRIPTION
Split `requirements-dev.txt` file into `requirements-tests.txt` and `requirements-linter.txt` files.
Add testing specific requirements to the `requirements-tests.txt` file.
Add linter specific requirements to `requirements-linter.txt`.