### PR TITLE
T41007 Optimize unit tests for API

### DIFF
--- a/tests/unit_tests/conftest.py
+++ b/tests/unit_tests/conftest.py
@@ -29,7 +29,8 @@ eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.\
 eyJzdWIiOiJib2IiLCJzY29wZXMiOlsiYWRtaW4iXX0.\
 t3bAE-pHSzZaSHp7FMlImqgYvL6f_0xDUD-nQwxEm3k'
 
-API_VERSION = '/latest'
+API_VERSION = 'latest'
+BASE_URL = f'http://testserver/{API_VERSION}/'
 
 
 @pytest.fixture

--- a/tests/unit_tests/conftest.py
+++ b/tests/unit_tests/conftest.py
@@ -34,9 +34,10 @@ BASE_URL = f'http://testserver/{API_VERSION}/'
 
 
 @pytest.fixture
-def client():
-    """Returns test client instance"""
-    return TestClient(app)
+def test_client():
+    """Fixture to get FastAPI Test client instance"""
+    with TestClient(app=app, base_url=BASE_URL) as client:
+        return client
 
 
 @pytest.fixture

--- a/tests/unit_tests/test_count_handler.py
+++ b/tests/unit_tests/test_count_handler.py
@@ -8,12 +8,7 @@
 """Unit test functions for KernelCI API count handler"""
 
 
-from fastapi.testclient import TestClient
-from tests.unit_tests.conftest import API_VERSION
-from api.main import app
-
-
-def test_count_nodes(mock_db_count, mock_init_sub_id):
+def test_count_nodes(mock_db_count, mock_init_sub_id, test_client):
     """
     Test Case : Test KernelCI API GET /count endpoint
     Expected Result :
@@ -21,14 +16,14 @@ def test_count_nodes(mock_db_count, mock_init_sub_id):
         Total number of nodes available
     """
     mock_db_count.return_value = 10
-    with TestClient(app) as client:
-        response = client.get(API_VERSION + "/count")
-        print("response.json()", response.json())
-        assert response.status_code == 200
-        assert response.json() >= 0
+    response = test_client.get("count")
+    print("response.json()", response.json())
+    assert response.status_code == 200
+    assert response.json() >= 0
 
 
-def test_count_nodes_matching_attributes(mock_db_count, mock_init_sub_id):
+def test_count_nodes_matching_attributes(mock_db_count, mock_init_sub_id,
+                                         test_client):
     """
     Test Case : Test KernelCI API GET /count endpoint with attributes
     Expected Result :
@@ -36,8 +31,7 @@ def test_count_nodes_matching_attributes(mock_db_count, mock_init_sub_id):
         Number of nodes matching attributes
     """
     mock_db_count.return_value = 1
-    with TestClient(app) as client:
-        response = client.get(API_VERSION + "/count?name=checkout")
-        print("response.json()", response.json())
-        assert response.status_code == 200
-        assert response.json() == 1
+    response = test_client.get("count?name=checkout")
+    print("response.json()", response.json())
+    assert response.status_code == 200
+    assert response.json() == 1

--- a/tests/unit_tests/test_listen_handler.py
+++ b/tests/unit_tests/test_listen_handler.py
@@ -10,16 +10,12 @@
 
 """Unit test functions for KernelCI API listen handler"""
 
-from fastapi.testclient import TestClient
-
-from tests.unit_tests.conftest import BEARER_TOKEN, API_VERSION
-
-from api.main import app
+from tests.unit_tests.conftest import BEARER_TOKEN
 
 
 def test_listen_endpoint(mock_get_current_user,
                          mock_init_sub_id,
-                         mock_listen):
+                         mock_listen, test_client):
     """
     Test Case : Test KernelCI API GET /listen endpoint for the
     positive path
@@ -29,18 +25,17 @@ def test_listen_endpoint(mock_get_current_user,
     """
     mock_listen.return_value = 'Listening for events on channel 1'
 
-    with TestClient(app) as client:
-        response = client.get(
-            API_VERSION + "/listen/1",
-            headers={
-                "Authorization": BEARER_TOKEN
-            },
-        )
-        assert response.status_code == 200
+    response = test_client.get(
+        "listen/1",
+        headers={
+            "Authorization": BEARER_TOKEN
+        },
+    )
+    assert response.status_code == 200
 
 
 def test_listen_endpoint_not_found(mock_get_current_user,
-                                   mock_init_sub_id):
+                                   mock_init_sub_id, test_client):
     """
     Test Case : Test KernelCI API GET /listen endpoint for the
     negative path
@@ -49,19 +44,18 @@ def test_listen_endpoint_not_found(mock_get_current_user,
         JSON with 'detail' key
         No existing pub/sub subscription with provided id
     """
-    with TestClient(app) as client:
-        response = client.get(
-            API_VERSION + "/listen/1",
-            headers={
-                "Authorization": BEARER_TOKEN
-            },
-        )
-        assert response.status_code == 404
-        assert 'detail' in response.json()
+    response = test_client.get(
+        "listen/1",
+        headers={
+            "Authorization": BEARER_TOKEN
+        },
+    )
+    assert response.status_code == 404
+    assert 'detail' in response.json()
 
 
 def test_listen_endpoint_without_token(mock_get_current_user,
-                                       mock_init_sub_id):
+                                       mock_init_sub_id, test_client):
     """
     Test Case : Test KernelCI API GET /listen endpoint for the
     negative path
@@ -69,11 +63,10 @@ def test_listen_endpoint_without_token(mock_get_current_user,
         HTTP Response Code 401 Unauthorized
         The request requires user authentication by token in header
     """
-    with TestClient(app) as client:
-        response = client.get(
-            API_VERSION + "/listen/1",
-            headers={
-                "Accept": "application/json"
-            },
-        )
-        assert response.status_code == 401
+    response = test_client.get(
+        "listen/1",
+        headers={
+            "Accept": "application/json"
+        },
+    )
+    assert response.status_code == 401

--- a/tests/unit_tests/test_me_handler.py
+++ b/tests/unit_tests/test_me_handler.py
@@ -7,14 +7,10 @@
 
 """Unit test function for KernelCI API me handler"""
 
-from fastapi.testclient import TestClient
-
-from tests.unit_tests.conftest import BEARER_TOKEN, API_VERSION
-
-from api.main import app
+from tests.unit_tests.conftest import BEARER_TOKEN
 
 
-def test_me_endpoint(mock_get_current_user):
+def test_me_endpoint(mock_get_current_user, mock_init_sub_id, test_client):
     """
     Test Case : Test KernelCI API /me endpoint
     Expected Result :
@@ -22,9 +18,8 @@ def test_me_endpoint(mock_get_current_user):
         JSON with '_id', 'username', 'hashed_password'
         and 'active' keys
     """
-    client = TestClient(app)
-    response = client.get(
-        API_VERSION + "/me",
+    response = test_client.get(
+        "me",
         headers={
             "Accept": "application/json",
             "Authorization": BEARER_TOKEN

--- a/tests/unit_tests/test_root_handler.py
+++ b/tests/unit_tests/test_root_handler.py
@@ -3,18 +3,18 @@
 # Copyright (C) 2022 Jeny Sadadia
 # Author: Jeny Sadadia <jeny.sadadia@gmail.com>
 
+# pylint: disable=unused-argument
+
 """Unit test function for KernelCI API root handler"""
 
-from tests.unit_tests.conftest import API_VERSION
 
-
-def test_root_endpoint(client):
+def test_root_endpoint(mock_init_sub_id, test_client):
     """
     Test Case : Test KernelCI API root endpoint
     Expected Result :
         HTTP Response Code 200 OK
         JSON with 'message' key
     """
-    response = client.get(API_VERSION + "/")
+    response = test_client.get("/latest")
     assert response.status_code == 200
     assert response.json() == {"message": "KernelCI API"}

--- a/tests/unit_tests/test_subscribe_handler.py
+++ b/tests/unit_tests/test_subscribe_handler.py
@@ -7,15 +7,12 @@
 
 """Unit test function for KernelCI API subscribe handler"""
 
-from fastapi.testclient import TestClient
-
-from tests.unit_tests.conftest import BEARER_TOKEN, API_VERSION
-from api.main import app
+from tests.unit_tests.conftest import BEARER_TOKEN
 from api.pubsub import Subscription
 
 
 def test_subscribe_endpoint(mock_get_current_user, mock_init_sub_id,
-                            mock_subscribe):
+                            mock_subscribe, test_client):
     """
     Test Case : Test KernelCI API /subscribe endpoint
     Expected Result :
@@ -25,14 +22,12 @@ def test_subscribe_endpoint(mock_get_current_user, mock_init_sub_id,
     subscribe = Subscription(id=1, channel='abc')
     mock_subscribe.return_value = subscribe
 
-    with TestClient(app) as client:
-        # Use context manager to trigger a startup event on the app object
-        response = client.post(
-            API_VERSION + "/subscribe/abc",
-            headers={
-                "Authorization": BEARER_TOKEN
-            },
-        )
-        print("response.json()", response.json())
-        assert response.status_code == 200
-        assert ('id', 'channel') == tuple(response.json().keys())
+    response = test_client.post(
+        "subscribe/abc",
+        headers={
+            "Authorization": BEARER_TOKEN
+        },
+    )
+    print("response.json()", response.json())
+    assert response.status_code == 200
+    assert ('id', 'channel') == tuple(response.json().keys())

--- a/tests/unit_tests/test_token_handler.py
+++ b/tests/unit_tests/test_token_handler.py
@@ -6,16 +6,14 @@
 # Copyright (C) 2022 Collabora Limited
 # Author: Jeny Sadadia <jeny.sadadia@collabora.com>
 
+# pylint: disable=unused-argument
+
 """Unit test function for KernelCI API token handler"""
 
-from fastapi.testclient import TestClient
-
-from tests.unit_tests.conftest import API_VERSION
-from api.main import app
 from api.models import User
 
 
-def test_token_endpoint(mock_db_find_one):
+def test_token_endpoint(mock_db_find_one, mock_init_sub_id, test_client):
     """
     Test Case : Test KernelCI API token endpoint
     Expected Result :
@@ -27,9 +25,8 @@ def test_token_endpoint(mock_db_find_one):
                                 'xCZGmM8jWXUXJZ4K',
                 active=True)
     mock_db_find_one.return_value = user
-    client = TestClient(app)
-    response = client.post(
-       API_VERSION + "/token",
+    response = test_client.post(
+        "token",
         headers={
             "Accept": "application/json",
             "Content-Type": "application/x-www-form-urlencoded"
@@ -41,7 +38,8 @@ def test_token_endpoint(mock_db_find_one):
     assert ('access_token', 'token_type') == tuple(response.json().keys())
 
 
-def test_token_endpoint_incorrect_password(mock_db_find_one):
+def test_token_endpoint_incorrect_password(mock_db_find_one, mock_init_sub_id,
+                                           test_client):
     """
     Test Case : Test KernelCI API token endpoint for negative path
     Incorrect password should be passed to the endpoint
@@ -55,11 +53,10 @@ def test_token_endpoint_incorrect_password(mock_db_find_one):
                                 'xCZGmM8jWXUXJZ4K',
                 active=True)
     mock_db_find_one.return_value = user
-    client = TestClient(app)
 
     # Pass incorrect password
-    response = client.post(
-        API_VERSION + "/token",
+    response = test_client.post(
+        "token",
         headers={
             "Accept": "application/json",
             "Content-Type": "application/x-www-form-urlencoded"
@@ -71,7 +68,8 @@ def test_token_endpoint_incorrect_password(mock_db_find_one):
     assert response.json() == {'detail': 'Incorrect username or password'}
 
 
-def test_token_endpoint_admin_user(mock_db_find_one):
+def test_token_endpoint_admin_user(mock_db_find_one, mock_init_sub_id,
+                                   test_client):
     """
     Test Case : Test KernelCI API token endpoint for admin user
     Expected Result :
@@ -83,9 +81,8 @@ def test_token_endpoint_admin_user(mock_db_find_one):
                                 'xCZGmM8jWXUXJZ4K',
                 active=True, is_admin=True)
     mock_db_find_one.return_value = user
-    client = TestClient(app)
-    response = client.post(
-        API_VERSION + "/token",
+    response = test_client.post(
+        "token",
         headers={
             "Accept": "application/json",
             "Content-Type": "application/x-www-form-urlencoded"

--- a/tests/unit_tests/test_unsubscribe_handler.py
+++ b/tests/unit_tests/test_unsubscribe_handler.py
@@ -7,44 +7,39 @@
 
 """Unit test functions for KernelCI API unsubscribe handler"""
 
-from fastapi.testclient import TestClient
-
-from tests.unit_tests.conftest import BEARER_TOKEN, API_VERSION
-from api.main import app
+from tests.unit_tests.conftest import BEARER_TOKEN
 
 
 def test_unsubscribe_endpoint(mock_get_current_user,
-                              mock_init_sub_id, mock_unsubscribe):
+                              mock_init_sub_id, mock_unsubscribe, test_client):
     """
     Test Case : Test KernelCI API /unsubscribe endpoint positive path
     Expected Result :
         HTTP Response Code 200 OK
     """
-    with TestClient(app) as client:
-        response = client.post(
-            API_VERSION + "/unsubscribe/1",
-            headers={
-                "Authorization": BEARER_TOKEN
-            },
-        )
-        assert response.status_code == 200
+    response = test_client.post(
+        "unsubscribe/1",
+        headers={
+            "Authorization": BEARER_TOKEN
+        },
+    )
+    assert response.status_code == 200
 
 
 def test_unsubscribe_endpoint_empty_response(mock_get_current_user,
-                                             mock_init_sub_id):
+                                             mock_init_sub_id, test_client):
     """
     Test Case : Test KernelCI API /unsubscribe endpoint negative path
     Expected Result :
         HTTP Response Code 404 Not Found
         JSON with 'detail' key
     """
-    with TestClient(app) as client:
-        response = client.post(
-            API_VERSION + "/unsubscribe/1",
-            headers={
-                "Authorization": BEARER_TOKEN
-            },
-        )
-        print("response.json()", response.json())
-        assert response.status_code == 404
-        assert 'detail' in response.json()
+    response = test_client.post(
+        "unsubscribe/1",
+        headers={
+            "Authorization": BEARER_TOKEN
+        },
+    )
+    print("response.json()", response.json())
+    assert response.status_code == 404
+    assert 'detail' in response.json()

--- a/tests/unit_tests/test_user_handler.py
+++ b/tests/unit_tests/test_user_handler.py
@@ -9,19 +9,16 @@
 
 import json
 
-from fastapi.testclient import TestClient
-
 from tests.unit_tests.conftest import (
     ADMIN_BEARER_TOKEN,
     BEARER_TOKEN,
-    API_VERSION,
 )
-from api.main import app
 from api.models import User
 
 
 def test_create_regular_user(mock_init_sub_id, mock_get_current_admin_user,
-                             mock_db_create, mock_publish_cloudevent):
+                             mock_db_create, mock_publish_cloudevent,
+                             test_client):
     """
     Test Case : Test KernelCI API /user endpoint to create regular user
     when requested with admin user's bearer token
@@ -34,23 +31,23 @@ def test_create_regular_user(mock_init_sub_id, mock_get_current_admin_user,
 HR5UHMdMFQeOe1eD4oXaP08oW7ogYqyiNziZYNdUHs8i", active=True)
     mock_db_create.return_value = user
 
-    with TestClient(app) as client:
-        response = client.post(
-            API_VERSION + "/user/test",
-            headers={
-                "Accept": "application/json",
-                "Authorization": ADMIN_BEARER_TOKEN
-            },
-            data=json.dumps({"password": "test"})
-        )
-        print(response.json())
-        assert response.status_code == 200
-        assert ('_id', 'username', 'hashed_password', 'active',
-                'is_admin') == tuple(response.json().keys())
+    response = test_client.post(
+        "user/test",
+        headers={
+            "Accept": "application/json",
+            "Authorization": ADMIN_BEARER_TOKEN
+        },
+        data=json.dumps({"password": "test"})
+    )
+    print(response.json())
+    assert response.status_code == 200
+    assert ('_id', 'username', 'hashed_password', 'active',
+            'is_admin') == tuple(response.json().keys())
 
 
 def test_create_admin_user(mock_init_sub_id, mock_get_current_admin_user,
-                           mock_db_create, mock_publish_cloudevent):
+                           mock_db_create, mock_publish_cloudevent,
+                           test_client):
     """
     Test Case : Test KernelCI API /user endpoint to create admin user
     when requested with admin user's bearer token
@@ -63,23 +60,22 @@ def test_create_admin_user(mock_init_sub_id, mock_get_current_admin_user,
 HR5UHMdMFQeOe1eD4oXaP08oW7ogYqyiNziZYNdUHs8i", active=True, is_admin=True)
     mock_db_create.return_value = user
 
-    with TestClient(app) as client:
-        response = client.post(
-            API_VERSION + "/user/test_admin?is_admin=1",
-            headers={
-                "Accept": "application/json",
-                "Authorization": ADMIN_BEARER_TOKEN
-            },
-            data=json.dumps({"password": "test"})
-        )
-        print(response.json())
-        assert response.status_code == 200
-        assert ('_id', 'username', 'hashed_password', 'active',
-                'is_admin') == tuple(response.json().keys())
+    response = test_client.post(
+        "user/test_admin?is_admin=1",
+        headers={
+            "Accept": "application/json",
+            "Authorization": ADMIN_BEARER_TOKEN
+        },
+        data=json.dumps({"password": "test"})
+    )
+    print(response.json())
+    assert response.status_code == 200
+    assert ('_id', 'username', 'hashed_password', 'active',
+            'is_admin') == tuple(response.json().keys())
 
 
 def test_create_user_endpoint_negative(mock_init_sub_id, mock_get_current_user,
-                                       mock_publish_cloudevent):
+                                       mock_publish_cloudevent, test_client):
     """
     Test Case : Test KernelCI API /user endpoint when requested
     with regular user's bearer token
@@ -89,15 +85,14 @@ def test_create_user_endpoint_negative(mock_init_sub_id, mock_get_current_user,
     """
     mock_get_current_user.return_value = None, "Access denied"
 
-    with TestClient(app) as client:
-        response = client.post(
-            API_VERSION + "/user/test",
-            headers={
-                "Accept": "application/json",
-                "Authorization": BEARER_TOKEN
-            },
-            data=json.dumps({"password": "test"})
-        )
-        print(response.json())
-        assert response.status_code == 401
-        assert response.json() == {'detail': 'Access denied'}
+    response = test_client.post(
+        "user/test",
+        headers={
+            "Accept": "application/json",
+            "Authorization": BEARER_TOKEN
+        },
+        data=json.dumps({"password": "test"})
+    )
+    print(response.json())
+    assert response.status_code == 401
+    assert response.json() == {'detail': 'Access denied'}


### PR DESCRIPTION
Optimize unit tests.

Create base URL for FastAPI TestClient from default test server URL along with API version.
Instead of creating `TestClient` instance from unit test functions, use the fixture.
Drop using `API_VERSION` from the request paths as `TestClient.base_url` will contain it by default.
Also, drop imports for using API_VERSION and TestClient.

Created on top of https://github.com/kernelci/kernelci-api/pull/220
