### PR TITLE
api.main: rename "me" as "whoami"

### DIFF
--- a/api/main.py
+++ b/api/main.py
@@ -177,9 +177,9 @@ async def login_for_access_token(
     return {"access_token": access_token, "token_type": "bearer"}
 
 
-@app.get('/me', response_model=User)
-async def read_users_me(current_user: User = Depends(get_user)):
-    """Get user information"""
+@app.get('/whoami', response_model=User)
+async def whoami(current_user: User = Depends(get_user)):
+    """Get current user information"""
     return current_user
 
 

--- a/tests/e2e_tests/test_user_creation.py
+++ b/tests/e2e_tests/test_user_creation.py
@@ -99,16 +99,16 @@ async def test_create_regular_user(test_async_client):
 
 
 @pytest.mark.dependency(depends=["test_create_regular_user"])
-def test_me_endpoint(test_client):
+def test_whoami(test_client):
     """
-    Test Case : Test KernelCI API /me endpoint
+    Test Case : Test KernelCI API /whoami endpoint
     Expected Result :
         HTTP Response Code 200 OK
         JSON with '_id', 'username', 'hashed_password'
         and 'active' keys
     """
     response = test_client.get(
-        "me",
+        "whoami",
         headers={
             "Accept": "application/json",
             "Authorization": f"Bearer {pytest.BEARER_TOKEN}"

--- a/tests/unit_tests/test_whoami_handler.py
+++ b/tests/unit_tests/test_whoami_handler.py
@@ -5,21 +5,21 @@
 
 # pylint: disable=unused-argument
 
-"""Unit test function for KernelCI API me handler"""
+"""Unit test function for KernelCI API whoami handler"""
 
 from tests.unit_tests.conftest import BEARER_TOKEN
 
 
-def test_me_endpoint(mock_get_current_user, mock_init_sub_id, test_client):
+def test_whoami_endpoint(mock_get_current_user, mock_init_sub_id, test_client):
     """
-    Test Case : Test KernelCI API /me endpoint
+    Test Case : Test KernelCI API /whoami endpoint
     Expected Result :
         HTTP Response Code 200 OK
         JSON with '_id', 'username', 'hashed_password'
         and 'active' keys
     """
     response = test_client.get(
-        "me",
+        "whoami",
         headers={
             "Accept": "application/json",
             "Authorization": BEARER_TOKEN


### PR DESCRIPTION
Rename the /me entry point as /whoami which refers to the standard "whoami" tool to retrieve information about the current user.  This is a better description of what the purpose of the endpoint and would avoid ambiguity with other endpoints related to the current user such as profile information etc.