### PR TITLE
api.pubsub: fix attributes logic in publish_cloudevent

### DIFF
--- a/api/pubsub.py
+++ b/api/pubsub.py
@@ -147,7 +147,7 @@ class PubSub:
         populated by default if not provided.  See the CloudEvent documentation
         for more details.
         """
-        if attributes is None:
+        if not attributes:
             attributes = {
                 "type": "api.kernelci.org",
                 "source": self._settings.cloud_events_source,


### PR DESCRIPTION
Fix the test that looks for user-provided attributes as it may be either None or an empty dictionary, not just None or valid attributes.