### PR TITLE
docker/api: upgrade to cloudevents 1.9.0

### DIFF
--- a/docker/api/requirements.txt
+++ b/docker/api/requirements.txt
@@ -1,5 +1,5 @@
 aioredis[hiredis]==2.0.0
-cloudevents==1.2.0
+cloudevents==1.9.0
 fastapi[all]==0.68.1
 fastapi-pagination==0.9.3
 passlib==1.7.4


### PR DESCRIPTION
Upgrade cloudevents to 1.9.0 to get the latest improvements and also enable checking type-safety with mypy.