### PR TITLE
T41382 Fix `create_admin_user` script with API version

### DIFF
--- a/create_admin_user
+++ b/create_admin_user
@@ -18,7 +18,7 @@ import sys
 import urllib
 
 
-DEFAULT_URL = 'http://localhost:8001'
+DEFAULT_URL = 'http://localhost:8001/latest/'
 
 
 def get_hashed_password(password, url):

--- a/create_admin_user
+++ b/create_admin_user
@@ -23,7 +23,7 @@ DEFAULT_URL = 'http://localhost:8001/latest/'
 
 def get_hashed_password(password, url):
     """Method to get hashed password"""
-    url = urllib.parse.urljoin(url, '/hash')
+    url = urllib.parse.urljoin(url, 'hash')
     data = {'password': password}
     res = requests.post(url, data=json.dumps(data))
     return res.json()


### PR DESCRIPTION
As a part of API versioning implementation, append API version `latest` suffix to default
URL used for requesting API endpoints to create an admin user. Adjust URL path for `/hash` endpoint accordingly for correct URL parsing.