### PR TITLE
T41424 Enable autoindex in nginx

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -38,6 +38,7 @@ services:
     image: 'nginx:1.21.3'
     volumes:
       - './docker/storage/data:/usr/share/nginx/html'
+      - './docker/storage/config/nginx.conf:/etc/nginx/conf.d/default.conf'
     ports:
       - ${STORAGE_HOST_PORT:-8002}:80
 

--- a/docker/storage/config/nginx.conf
+++ b/docker/storage/config/nginx.conf
@@ -1,0 +1,45 @@
+server {
+    listen       80;
+    listen  [::]:80;
+    server_name  localhost;
+
+    #access_log  /var/log/nginx/host.access.log  main;
+
+    location / {
+        autoindex on;
+        root   /usr/share/nginx/html;
+        index  index.html index.htm;
+    }
+
+    #error_page  404              /404.html;
+
+    # redirect server error pages to the static page /50x.html
+    #
+    error_page   500 502 503 504  /50x.html;
+    location = /50x.html {
+        root   /usr/share/nginx/html;
+    }
+
+    # proxy the PHP scripts to Apache listening on 127.0.0.1:80
+    #
+    #location ~ \.php$ {
+    #    proxy_pass   http://127.0.0.1;
+    #}
+
+    # pass the PHP scripts to FastCGI server listening on 127.0.0.1:9000
+    #
+    #location ~ \.php$ {
+    #    root           html;
+    #    fastcgi_pass   127.0.0.1:9000;
+    #    fastcgi_index  index.php;
+    #    fastcgi_param  SCRIPT_FILENAME  /scripts$fastcgi_script_name;
+    #    include        fastcgi_params;
+    #}
+
+    # deny access to .htaccess files, if Apache's document root
+    # concurs with nginx's one
+    #
+    #location ~ /\.ht {
+    #    deny  all;
+    #}
+}


### PR DESCRIPTION
Fixes https://github.com/kernelci/kernelci-api/issues/230 

Created directory `config`  under `docker.storage` to store configuration file for `storage` service.
Added `nginx.conf` file to modify `server` block copied from `/etc/nginx/conf.d/default.conf` to enable autoindex.
Mounted the config file in `docker-compose`.