### PR TITLE
Fix URLs for `openapi.json`

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ it](http://localhost:8001/latest/docs) with a web browser.  Then click on
 "Authorize" button.
 
 This is based on OpenAPI, and you can also download the `openapi.json` file to
-use it with other tools: http://localhost:8001/openapi.json
+use it with other tools: http://localhost:8001/latest/openapi.json
 
 
 ## API Testing

--- a/doc/overview.md
+++ b/doc/overview.md
@@ -56,7 +56,8 @@ characteristics:
   asynchronous request handling, data model validation using
   [Pydantic](https://pydantic-docs.helpmanual.io/), automatically generated
   documentation with [OpenAPI](https://www.openapis.org/).  See also the
-  [OpenAPI JSON description](https://staging.kernelci.org:9000/openapi.json).
+  [OpenAPI JSON
+  description](https://staging.kernelci.org:9000/latest/openapi.json).
 * Pub/Sub mechanism via the API, with [Redis](https://redis.io/) to manage
   message queues.  This can now be used to coordinate client-side functions and
   recreate a full modular pipeline with no additional framework


### PR DESCRIPTION
Add the missing `latest/` API version prefix to URLs for the `openapi.json` file.  The URLs without the prefix return a top-level JSON file which is not a description of the actual API.