### PR TITLE
api.models: use (str, Enum) as mixin for string enums

### DIFF
--- a/api/models.py
+++ b/api/models.py
@@ -43,7 +43,7 @@ class PyObjectId(ObjectId):
         return ObjectId(value)
 
 
-class StateValues(enum.Enum):
+class StateValues(str, enum.Enum):
     """Enumeration to declare values to be used for Node.state"""
 
     RUNNING = 'running'
@@ -52,7 +52,7 @@ class StateValues(enum.Enum):
     DONE = 'done'
 
 
-class ResultValues(enum.Enum):
+class ResultValues(str, enum.Enum):
     """Enumeration to declare values to be used for Node.result"""
 
     PASS = 'pass'


### PR DESCRIPTION
Use (str, Enum) as mixin parent classes for Enum fields that are only strings.  This helps ensure that only strings are accepted as values for these Enum types.