### PR TITLE
Add extra fields in the Node event data

### DIFF
--- a/api/main.py
+++ b/api/main.py
@@ -196,6 +196,12 @@ def _get_node_event_data(operation, node):
     return {
         'op': operation,
         'id': str(node.id),
+        'name': node.name,
+        'path': node.path,
+        'group': node.group,
+        'state': node.state,
+        'result': node.result,
+        'revision': node.revision.dict(),
     }
 
 

--- a/tests/e2e_tests/test_pipeline.py
+++ b/tests/e2e_tests/test_pipeline.py
@@ -58,7 +58,8 @@ async def test_node_pipeline(test_async_client):
     # Get result of pubsub event listen task
     await task_listen
     event_data = from_json(task_listen.result().json().get('data')).data
-    assert ('op', 'id') == tuple(event_data.keys())
+    keys = {'op', 'id', 'name', 'path', 'group', 'state', 'result', 'revision'}
+    assert keys == event_data.keys()
     assert event_data.get('op') == 'created'
     assert event_data.get('id') == response.json()['_id']
 
@@ -78,5 +79,6 @@ async def test_node_pipeline(test_async_client):
     # Get result of pubsub event listen task
     await task_listen
     event_data = from_json(task_listen.result().json().get('data')).data
-    assert ('op', 'id') == tuple(event_data.keys())
+    keys = {'op', 'id', 'name', 'path', 'group', 'state', 'result', 'revision'}
+    assert keys == event_data.keys()
     assert event_data.get('op') == 'updated'


### PR DESCRIPTION
Consolidate the code used to send events when Node objects are being created or updated, and add some extra fields to avoid always fetching the whole Node object.  This should provide enough information for a pipeline to determine which jobs should be run next based on the event itself.