### PR TITLE
api.models: allow Node.kind to take other values than 'node'

### DIFF
--- a/api/models.py
+++ b/api/models.py
@@ -192,8 +192,7 @@ class Node(DatabaseModel):
     """KernelCI primitive node object model for generic test results"""
     kind: str = Field(
         default='node',
-        description='Type of the object',
-        const=True
+        description='Type of the object'
     )
     name: str = Field(
         description='Name of the node object'


### PR DESCRIPTION
Remove const=True from Node.kind to allow it to have other values than the default 'node'.  This is to be able to deduce if Node.data should be validated against a particular model, or to know its type in general.

The original assumption was that we would have derivative classes from Node but this isn't too practical as the base class can't be used with Pydantic with derivated objects since it can't validate the extra fields.  So instead, Node can become a more general class rather than having specialised derivative ones.  The Node.data part can be used for specialisation instead.