### PR TITLE
T41958 api/models: fix getting regression nodes failure

### DIFF
--- a/api/models.py
+++ b/api/models.py
@@ -349,23 +349,15 @@ class Regression(Node):
         description='Regression details'
     )
 
-    _OBJECT_ID_FIELDS = [
+    _OBJECT_ID_FIELDS = Node._OBJECT_ID_FIELDS + [
         'regression_data.parent',
     ]
-    _TIMESTAMP_FIELDS = [
+    _TIMESTAMP_FIELDS = Node._TIMESTAMP_FIELDS + [
         'regression_data.created',
         'regression_data.updated',
         'regression_data.timeout',
         'regression_data.holdoff',
     ]
-
-    @classmethod
-    def translate_fields(cls, params: dict):
-        """Translate regression parameters"""
-        translated = cls.translate_fields(params)
-        translated.update(cls._translate_object_ids(translated))
-        translated.update(cls._translate_timestamps(translated))
-        return translated
 
 
 def get_model_from_kind(kind: str):


### PR DESCRIPTION
Fix the below error while trying to get nodes with `kind=regression`:

```
today at 14:08:18INFO:     172.24.0.1:58850 - "GET /latest/nodes?kind=regression HTTP/1.0" 500 Internal Server Error
today at 14:08:18ERROR:    Exception in ASGI application
today at 14:08:18Traceback (most recent call last):
today at 14:08:18  File "/home/kernelci/.local/lib/python3.10/site-packages/uvicorn/protocols/http/httptools_impl.py", line 398, in run_asgi
today at 14:08:18    result = await app(self.scope, self.receive, self.send)
today at 14:08:18  File "/home/kernelci/.local/lib/python3.10/site-packages/uvicorn/middleware/proxy_headers.py", line 45, in __call__
today at 14:08:18    return await self.app(scope, receive, send)
today at 14:08:18  File "/home/kernelci/.local/lib/python3.10/site-packages/fastapi/applications.py", line 208, in __call__
today at 14:08:18    await super().__call__(scope, receive, send)
today at 14:08:18  File "/home/kernelci/.local/lib/python3.10/site-packages/starlette/applications.py", line 112, in __call__
today at 14:08:18    await self.middleware_stack(scope, receive, send)
today at 14:08:18  File "/home/kernelci/.local/lib/python3.10/site-packages/starlette/middleware/errors.py", line 181, in __call__
today at 14:08:18    raise exc from None
today at 14:08:18  File "/home/kernelci/.local/lib/python3.10/site-packages/starlette/middleware/errors.py", line 159, in __call__
today at 14:08:18    await self.app(scope, receive, _send)
today at 14:08:18  File "/home/kernelci/.local/lib/python3.10/site-packages/starlette/exceptions.py", line 82, in __call__
today at 14:08:18    raise exc from None
today at 14:08:18  File "/home/kernelci/.local/lib/python3.10/site-packages/starlette/exceptions.py", line 71, in __call__
today at 14:08:18    await self.app(scope, receive, sender)
today at 14:08:18  File "/home/kernelci/.local/lib/python3.10/site-packages/starlette/routing.py", line 580, in __call__
today at 14:08:18    await route.handle(scope, receive, send)
today at 14:08:18  File "/home/kernelci/.local/lib/python3.10/site-packages/starlette/routing.py", line 390, in handle
today at 14:08:18    await self.app(scope, receive, send)
today at 14:08:18  File "/home/kernelci/.local/lib/python3.10/site-packages/fastapi/applications.py", line 208, in __call__
today at 14:08:18    await super().__call__(scope, receive, send)
today at 14:08:18  File "/home/kernelci/.local/lib/python3.10/site-packages/starlette/applications.py", line 112, in __call__
today at 14:08:18    await self.middleware_stack(scope, receive, send)
today at 14:08:18  File "/home/kernelci/.local/lib/python3.10/site-packages/starlette/middleware/errors.py", line 181, in __call__
today at 14:08:18    raise exc from None
today at 14:08:18  File "/home/kernelci/.local/lib/python3.10/site-packages/starlette/middleware/errors.py", line 159, in __call__
today at 14:08:18    await self.app(scope, receive, _send)
today at 14:08:18  File "/home/kernelci/.local/lib/python3.10/site-packages/starlette/exceptions.py", line 82, in __call__
today at 14:08:18    raise exc from None
today at 14:08:18  File "/home/kernelci/.local/lib/python3.10/site-packages/starlette/exceptions.py", line 71, in __call__
today at 14:08:18    await self.app(scope, receive, sender)
today at 14:08:18  File "/home/kernelci/.local/lib/python3.10/site-packages/starlette/routing.py", line 580, in __call__
today at 14:08:18    await route.handle(scope, receive, send)
today at 14:08:18  File "/home/kernelci/.local/lib/python3.10/site-packages/starlette/routing.py", line 241, in handle
today at 14:08:18    await self.app(scope, receive, send)
today at 14:08:18  File "/home/kernelci/.local/lib/python3.10/site-packages/starlette/routing.py", line 52, in app
today at 14:08:18    response = await func(request)
today at 14:08:18  File "/home/kernelci/.local/lib/python3.10/site-packages/fastapi/routing.py", line 226, in app
today at 14:08:18    raw_response = await run_endpoint_function(
today at 14:08:18  File "/home/kernelci/.local/lib/python3.10/site-packages/fastapi/routing.py", line 159, in run_endpoint_function
today at 14:08:18    return await dependant.call(**values)
today at 14:08:18  File "/home/kernelci/./api/main.py", line 232, in get_nodes
today at 14:08:18    translated_params = model.translate_fields(query_params)
today at 14:08:18  File "/home/kernelci/./api/models.py", line 384, in translate_fields
today at 14:08:18    translated = cls.translate_fields(params)
today at 14:08:18  File "/home/kernelci/./api/models.py", line 384, in translate_fields
today at 14:08:18    translated = cls.translate_fields(params)
today at 14:08:18  File "/home/kernelci/./api/models.py", line 384, in translate_fields
today at 14:08:18    translated = cls.translate_fields(params)
today at 14:08:18  [Previous line repeated 969 more times]
today at 14:08:18RecursionError: maximum recursion depth exceeded
```