### PR TITLE
api.models: drop Node.validate_params()

### DIFF
--- a/api/main.py
+++ b/api/main.py
@@ -241,7 +241,6 @@ async def get_nodes(request: Request, kind: str = "node"):
 
     try:
         model = get_model_from_kind(kind)
-        model.validate_params(query_params)
         translated_params = model.translate_fields(query_params)
         return await db.find_by_attributes(model, translated_params)
     except KeyError as error:
@@ -263,7 +262,6 @@ async def get_nodes_count(request: Request, kind: str = "node"):
 
     try:
         model = get_model_from_kind(kind)
-        model.validate_params(query_params)
         translated_params = model.translate_fields(query_params)
         return await db.count(model, translated_params)
     except KeyError as error:

--- a/api/models.py
+++ b/api/models.py
@@ -242,27 +242,6 @@ class Node(DatabaseModel):
         self.updated = datetime.utcnow()
 
     @classmethod
-    def validate_state(cls, state):
-        """Validate Node.state"""
-        if state and state not in [state.value for state in StateValues]:
-            raise ValueError(f"Invalid state value '{state}'")
-
-    @classmethod
-    def validate_result(cls, result):
-        """Validate Node.result"""
-        if result and result not in [result.value for result in ResultValues]:
-            raise ValueError(f"Invalid result value '{result}'")
-
-    @classmethod
-    def validate_params(cls, params: dict):
-        """Validate Node parameters"""
-        Node.validate_state(params.get('state'))
-        Node.validate_result(params.get('result'))
-        parent = params.get('parent')
-        if parent:
-            PyObjectId.validate(parent)
-
-    @classmethod
     def _translate_operators(cls, params):
         """Translate fields with an operator
 
@@ -378,17 +357,6 @@ class Regression(Node):
         'regression_data.timeout',
         'regression_data.holdoff',
     ]
-
-    @classmethod
-    def validate_params(cls, params: dict):
-        """Validate regression parameters"""
-        Node.validate_params(params)
-        Node.validate_state(params.get('regression_data.state'))
-        Node.validate_result(params.get('regression_data.result'))
-
-        parent = params.get('regression_data.parent')
-        if parent:
-            PyObjectId.validate(parent)
 
     @classmethod
     def translate_fields(cls, params: dict):


### PR DESCRIPTION
Drop the Node.validate_params() custom validation method used with GET queries as invalid values will not match any result and this is used with fuzzy-matching queries that don't validate the input using Pydantic.  Also, values of the wrong type are already reported as errors by the lower layers.  For example, with an invalid ObjectId:

    $ ./kci node find parent=xyz --limit=1
    400 Client Error: Bad Request for url: http://172.17.0.1:8001/latest/nodes?parent=xyz&limit=1
    'xyz' is not a valid ObjectId, it must be a 12-byte input or a 24-character hex string

Other queries such as the POST and PUT ones rely directly on Pydantic to validate the input data against the model so there's no need for custom validation there either (and .validate_params() wasn't used in these cases, only with fuzzy-matching GET queries to find or count nodes).

Fixes: 513cb0a20fe9 ("api: Improve validation for request query params")

Replaces #242 