### PR TITLE
api.main: add response model for `post_regression`

### DIFF
--- a/api/main.py
+++ b/api/main.py
@@ -357,7 +357,7 @@ async def publish(raw: dict, channel: str, user: User = Depends(get_user)):
 # -----------------------------------------------------------------------------
 # Regression
 
-@app.post('/regression')
+@app.post('/regression', response_model=Regression)
 async def post_regression(regression: Regression,
                           token: str = Depends(get_user)):
     """Create a new regression"""


### PR DESCRIPTION
Add specific pydantic model `Regression` as response model for `post_regression` handler. This is to use options like `response_model_by_alias` for further configuration. The flag won't have any effect without specifying the response model for the handler.