### PR TITLE
doc/api-details: fixup in sample command to create API tokens

### DIFF
--- a/doc/api-details.md
+++ b/doc/api-details.md
@@ -62,7 +62,7 @@ $ curl -X 'POST' \
   'http://localhost:8001/latest/token' \
   -H 'accept: application/json' \
   -H 'Content-Type: application/x-www-form-urlencoded' \
-  s-d 'grant_type=&username=test_admin&password=admin&scope=admin users'
+  -d 'grant_type=&username=test_admin&password=admin&scope=admin users'
 {'access_token': 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJ0ZXN0X2FkbWluIiwic2NvcGVzIjpbImFkbWluIl19.NWShAwOodFl2iCcDh0YB8O4xzfaRlIS4GkzUO8OQhQg', 'token_type': 'bearer'}
 ```
 


### PR DESCRIPTION
A minor fixup in the curl command in the section to create API tokens with security scopes.

Fixes: ed759c8 ("doc: get API token with scope")