### PR TITLE
Add support for user groups

### DIFF
--- a/api/db.py
+++ b/api/db.py
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: LGPL-2.1-or-later
 #
-# Copyright (C) 2021, 2022 Collabora Limited
+# Copyright (C) 2021-2023 Collabora Limited
 # Author: Guillaume Tucker <guillaume.tucker@collabora.com>
 # Author: Jeny Sadadia <jeny.sadadia@collabora.com>
 
@@ -9,7 +9,7 @@
 from bson import ObjectId
 from fastapi_pagination.ext.motor import paginate
 from motor import motor_asyncio
-from .models import Hierarchy, Node, User, Regression
+from .models import Hierarchy, Node, User, Regression, UserGroup
 
 
 class Database:
@@ -24,6 +24,7 @@ class Database:
         User: 'user',
         Node: 'node',
         Regression: 'regression',
+        UserGroup: 'usergroup',
     }
 
     OPERATOR_MAP = {

--- a/api/main.py
+++ b/api/main.py
@@ -168,6 +168,13 @@ async def get_user_groups(request: Request):
     return paginated_resp
 
 
+@app.get('/group/{group_id}', response_model=UserGroup,
+         response_model_by_alias=False)
+async def get_group(group_id: str):
+    """Get user group information from the provided group id"""
+    return await db.find_by_id(UserGroup, group_id)
+
+
 @app.get('/')
 async def root():
     """Root endpoint handler"""

--- a/api/main.py
+++ b/api/main.py
@@ -157,6 +157,17 @@ Use a different group name."
     return obj
 
 
+@app.get('/groups', response_model=PageModel)
+async def get_user_groups(request: Request):
+    """Get all the user groups if no request parameters have passed.
+       Get all the matching user groups otherwise."""
+    query_params = dict(request.query_params)
+    paginated_resp = await db.find_by_attributes(UserGroup, query_params)
+    paginated_resp.items = serialize_paginated_data(
+        UserGroup, paginated_resp.items)
+    return paginated_resp
+
+
 @app.get('/')
 async def root():
     """Root endpoint handler"""

--- a/api/models.py
+++ b/api/models.py
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: LGPL-2.1-or-later
 #
-# Copyright (C) 2021, 2022 Collabora Limited
+# Copyright (C) 2021-2023 Collabora Limited
 # Author: Guillaume Tucker <guillaume.tucker@collabora.com>
 # Author: Jeny Sadadia <jeny.sadadia@collabora.com>
 
@@ -102,6 +102,18 @@ class DatabaseModel(ModelId):
     @classmethod
     def create_indexes(cls, collection):
         """Method to create indexes"""
+
+
+class UserGroup(DatabaseModel):
+    """API model to group associated user accounts"""
+    name: str = Field(
+        description="User group name"
+    )
+
+    @classmethod
+    def create_indexes(cls, collection):
+        """Create an index to bind unique constraint to group name"""
+        collection.create_index("name", unique=True)
 
 
 class User(DatabaseModel):

--- a/init_user_groups
+++ b/init_user_groups
@@ -1,0 +1,31 @@
+#!/usr/bin/env python3
+#
+# SPDX-License-Identifier: LGPL-2.1-or-later
+#
+# Copyright (C) 2023 Collabora Limited
+# Author: Jeny Sadadia <jeny.sadadia@collabora.com>
+
+"""Command line utility for creating default groups"""
+
+import subprocess
+
+
+DEFAULT_GROUPS = ['admin']
+
+def create_group(group_name):
+    """
+    Create user group
+    """
+    cmd = f"docker-compose exec db /bin/mongo kernelci --eval \
+\"db.usergroup.insert({{name: '{group_name}'}})\""
+    ret_code = subprocess.call(cmd, shell=True)
+    return ret_code == 0
+
+
+def main():
+    for group in DEFAULT_GROUPS:
+        if not create_group(group):
+            print(f"Failed to execute command for adding group: {group}")
+
+if __name__ == "__main__":
+    main()

--- a/tests/e2e_tests/test_user_group_creation.py
+++ b/tests/e2e_tests/test_user_group_creation.py
@@ -1,0 +1,27 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+#
+# Copyright (C) 2023 Collabora Limited
+# Author: Jeny Sadadia <jeny.sadadia@collabora.com>
+
+"""End-to-end test functions for KernelCI API user group creation"""
+
+import pytest
+
+from api.models import UserGroup
+from api.db import Database
+from e2e_tests.conftest import db_create
+
+
+@pytest.mark.dependency()
+@pytest.mark.order(1)
+@pytest.mark.asyncio
+async def test_create_user_groups():
+    """
+    Test Case : Create default user groups
+    """
+    default_user_groups = ['admin']
+    for group in default_user_groups:
+        obj = await db_create(
+            Database.COLLECTIONS[UserGroup],
+            UserGroup(name=group))
+        assert obj is not None


### PR DESCRIPTION
Add support for user groups.
- Added model `UserGroup`
- Added a python script to create default groups i.e. admin and users
- Added POST handler for it
- Added GET handler for it
- Added e2e test for user group creation