### PR TITLE
Store group in User model

### DIFF
--- a/api/models.py
+++ b/api/models.py
@@ -128,6 +128,10 @@ class User(DatabaseModel):
         default=False,
         description="True if superuser otherwise False"
     )
+    groups: List[UserGroup] = Field(
+        default=[],
+        description="A list of groups that user belongs to"
+    )
 
     @classmethod
     def create_indexes(cls, collection):

--- a/create_admin_user
+++ b/create_admin_user
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: LGPL-2.1-or-later
 #
-# Copyright (C) 2022 Collabora Limited
+# Copyright (C) 2022, 2023 Collabora Limited
 # Author: Jeny Sadadia <jeny.sadadia@collabora.com>
 # Author: Michal Galka <michal.galka@collabora.com>
 
@@ -29,21 +29,34 @@ def get_hashed_password(password, url):
     return res.json()
 
 
-def create_admin(username, hashed_password):
+def get_admin_group_obj(url):
+    """Check if user group 'admin' exists"""
+    url = urllib.parse.urljoin('http://localhost:8001/latest/', 'groups?name=admin')
+    res = requests.get(url)
+    if not res.json()['total']:
+        return None
+    return res.json()['items'][0]
+
+
+def create_admin(username, hashed_password, admin_group):
     """
     Create an admin user
     """
     cmd = f"docker-compose exec db /bin/mongo kernelci --eval \
 \"db.user.insert({{username: '{username}', \
 hashed_password: '{re.escape(hashed_password)}', \
-active: true, is_admin: 1}})\""
+active: true, is_admin: 1, groups: [{admin_group}]}})\""
     ret_code = subprocess.call(cmd, shell=True)
     return ret_code == 0
 
 def main(args):
+    admin_group = get_admin_group_obj(args.url)
+    if not admin_group:
+        print("Error: Please create user group 'admin' before creating any admin user")
+        return False
     password = getpass.getpass()
     hashed_password = get_hashed_password(password, args.url)
-    return create_admin(args.username, hashed_password)
+    return create_admin(args.username, hashed_password, admin_group)
 
 
 if __name__ == "__main__":

--- a/tests/e2e_tests/test_pipeline.py
+++ b/tests/e2e_tests/test_pipeline.py
@@ -17,7 +17,7 @@ from .test_node_handler import create_node, get_node_by_id, update_node
     depends=[
         'e2e_tests/test_subscribe_handler.py::test_subscribe_node_channel'],
     scope='session')
-@pytest.mark.order(4)
+@pytest.mark.order(5)
 @pytest.mark.asyncio
 async def test_node_pipeline(test_async_client):
     """

--- a/tests/e2e_tests/test_subscribe_handler.py
+++ b/tests/e2e_tests/test_subscribe_handler.py
@@ -12,7 +12,7 @@ import pytest
 @pytest.mark.dependency(
     depends=['e2e_tests/test_user_creation.py::test_create_regular_user'],
     scope='session')
-@pytest.mark.order(3)
+@pytest.mark.order(4)
 def test_subscribe_node_channel(test_client):
     """
     Test Case : Test KernelCI API '/subscribe' endpoint with 'node' channel
@@ -35,7 +35,7 @@ def test_subscribe_node_channel(test_client):
 @pytest.mark.dependency(
     depends=['e2e_tests/test_user_creation.py::test_create_regular_user'],
     scope='session')
-@pytest.mark.order(3)
+@pytest.mark.order(4)
 def test_subscribe_test_channel(test_client):
     """
     Test Case : Test KernelCI API '/subscribe' endpoint with 'test_channel'

--- a/tests/unit_tests/conftest.py
+++ b/tests/unit_tests/conftest.py
@@ -3,7 +3,7 @@
 # Copyright (C) 2022 Jeny Sadadia
 # Author: Jeny Sadadia <jeny.sadadia@gmail.com>
 #
-# Copyright (C) 2022 Collabora Limited
+# Copyright (C) 2022, 2023 Collabora Limited
 # Author: Jeny Sadadia <jeny.sadadia@collabora.com>
 
 # pylint: disable=protected-access
@@ -17,7 +17,7 @@ from fastapi.testclient import TestClient
 import pytest
 
 from api.main import app
-from api.models import User
+from api.models import User, UserGroup
 from api.pubsub import PubSub
 
 BEARER_TOKEN = "Bearer \
@@ -132,7 +132,8 @@ def mock_get_current_admin_user(mocker):
     user = User(username='admin',
                 hashed_password='$2b$12$CpJZx5ooxM11bCFXT76/z.o6HWs2sPJy4iP8.'
                                 'xCZGmM8jWXUXJZ4K',
-                active=True, is_admin=True)
+                active=True, is_admin=True, groups=[
+                    UserGroup(name='admin')])
     mocker.patch('api.auth.Authentication.get_current_user',
                  side_effect=async_mock)
     async_mock.return_value = user, None

--- a/tests/unit_tests/test_token_handler.py
+++ b/tests/unit_tests/test_token_handler.py
@@ -3,14 +3,14 @@
 # Copyright (C) 2022 Jeny Sadadia
 # Author: Jeny Sadadia <jeny.sadadia@gmail.com>
 #
-# Copyright (C) 2022 Collabora Limited
+# Copyright (C) 2022, 2023 Collabora Limited
 # Author: Jeny Sadadia <jeny.sadadia@collabora.com>
 
 # pylint: disable=unused-argument
 
 """Unit test function for KernelCI API token handler"""
 
-from api.models import User
+from api.models import User, UserGroup
 
 
 def test_token_endpoint(mock_db_find_one, mock_init_sub_id, test_client):
@@ -23,7 +23,7 @@ def test_token_endpoint(mock_db_find_one, mock_init_sub_id, test_client):
     user = User(username='bob',
                 hashed_password='$2b$12$CpJZx5ooxM11bCFXT76/z.o6HWs2sPJy4iP8.'
                                 'xCZGmM8jWXUXJZ4K',
-                active=True)
+                active=True, groups=[])
     mock_db_find_one.return_value = user
     response = test_client.post(
         "token",
@@ -51,7 +51,7 @@ def test_token_endpoint_incorrect_password(mock_db_find_one, mock_init_sub_id,
     user = User(username='bob',
                 hashed_password='$2b$12$CpJZx5ooxM11bCFXT76/z.o6HWs2sPJy4iP8.'
                                 'xCZGmM8jWXUXJZ4K',
-                active=True)
+                active=True, groups=[])
     mock_db_find_one.return_value = user
 
     # Pass incorrect password
@@ -79,7 +79,7 @@ def test_token_endpoint_admin_user(mock_db_find_one, mock_init_sub_id,
     user = User(username='test_admin',
                 hashed_password='$2b$12$CpJZx5ooxM11bCFXT76/z.o6HWs2sPJy4iP8.'
                                 'xCZGmM8jWXUXJZ4K',
-                active=True, is_admin=True)
+                active=True, is_admin=True, groups=[UserGroup(name='admin')])
     mock_db_find_one.return_value = user
     response = test_client.post(
         "token",

--- a/tests/unit_tests/test_whoami_handler.py
+++ b/tests/unit_tests/test_whoami_handler.py
@@ -2,6 +2,9 @@
 #
 # Copyright (C) 2022 Jeny Sadadia
 # Author: Jeny Sadadia <jeny.sadadia@gmail.com>
+#
+# Copyright (C) 2023 Collabora Limited
+# Author: Jeny Sadadia <jeny.sadadia@collabora.com>
 
 # pylint: disable=unused-argument
 
@@ -27,4 +30,4 @@ def test_whoami_endpoint(mock_get_current_user, mock_init_sub_id, test_client):
     )
     assert response.status_code == 200
     assert ('_id', 'username', 'hashed_password', 'active',
-            'is_admin') == tuple(response.json().keys())
+            'is_admin', 'groups') == tuple(response.json().keys())


### PR DESCRIPTION
Depends on https://github.com/kernelci/kernelci-api/pull/265

Introduced `user_group` field in `User` model. Updated API endpoint for creating users to receive user group from query parameter and use it for user model creation.
Added a migration file to set `user_group` value to `admin` for admin users and `users` for regular users.
Also, update the script for creating admin users to check the existence of `admin` group before creating admin users.
Updated e2e tests and unit tests for the related changes.