### PR TITLE
tests/e2e_tests: add a dependency to `test_pubsub_handler`

### DIFF
--- a/tests/e2e_tests/test_pubsub_handler.py
+++ b/tests/e2e_tests/test_pubsub_handler.py
@@ -12,6 +12,9 @@ from cloudevents.http import CloudEvent, to_structured, from_json
 from .listen_handler import create_listen_task
 
 
+@pytest.mark.dependency(
+    depends=['e2e_tests/test_subscribe_handler.py::test_subscribe_test_channel'],
+    scope='session')
 @pytest.mark.asyncio
 async def test_pubsub_handler(test_async_client):
     """


### PR DESCRIPTION
Fixes https://github.com/kernelci/kernelci-api/issues/275

Test for pubsub uses pytest variable `test_channel_subscription_id` to listen to events on the test channel.
Since the subscription id variable is created from `test_subscribe_test_channel` test, insert a test dependency to the pubsub test handler.

This can avoid the below errors in case `test_subscribe_test_channel` fails,
```
kernelci-api-e2e-tests |         task_listen = create_listen_task(test_async_client,
kernelci-api-e2e-tests | >                                        pytest.test_channel_subscription_id)
kernelci-api-e2e-tests | E       AttributeError: module 'pytest' has no attribute 'test_channel_subscription_id'
kernelci-api-e2e-tests | 
kernelci-api-e2e-tests | e2e_tests/test_pubsub_handler.py:27: AttributeError
```