### PR TITLE
User ownership to nodes

### DIFF
--- a/api/main.py
+++ b/api/main.py
@@ -390,7 +390,8 @@ async def post_node(node: Node, current_user: str = Depends(get_user)):
 
 
 @app.put('/node/{node_id}', response_model=Node, response_model_by_alias=False)
-async def put_node(node_id: str, node: Node, token: str = Depends(get_user)):
+async def put_node(node_id: str, node: Node,
+                   user: str = Depends(authorize_user)):
     """Update an already added node"""
     node.id = ObjectId(node_id)
     node_from_id = await db.find_by_id(Node, node_id)
@@ -406,6 +407,11 @@ async def put_node(node_id: str, node: Node, token: str = Depends(get_user)):
             status_code=status.HTTP_400_BAD_REQUEST,
             detail=message
         )
+
+    # Do not update node ownership fields
+    update_data = node.dict(exclude={'user', 'user_groups'})
+    node = node_from_id.copy(update=update_data)
+
     obj = await db.update(node)
     data = _get_node_event_data('updated', obj)
     await pubsub.publish_cloudevent('node', data)

--- a/api/main.py
+++ b/api/main.py
@@ -342,8 +342,17 @@ async def get_nodes_count(request: Request, kind: str = "node"):
         ) from error
 
 
+async def _verify_user_group_existence(user_groups: List[str]):
+    """Check if user group exists"""
+    for group_name in user_groups:
+        if not await db.find_one(UserGroup, name=group_name):
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail=f"User group does not exist with name: {group_name}")
+
+
 @app.post('/node', response_model=Node, response_model_by_alias=False)
-async def post_node(node: Node, token: str = Depends(get_user)):
+async def post_node(node: Node, current_user: str = Depends(get_user)):
     """Create a new node"""
     if node.parent:
         parent = await db.find_by_id(Node, node.parent)
@@ -352,6 +361,9 @@ async def post_node(node: Node, token: str = Depends(get_user)):
                 status_code=status.HTTP_404_NOT_FOUND,
                 detail=f"Parent not found with id: {node.parent}"
             )
+
+    await _verify_user_group_existence(node.user_groups)
+    node.owner = current_user.username
     obj = await db.create(node)
     data = _get_node_event_data('created', obj)
     await pubsub.publish_cloudevent('node', data)

--- a/api/models.py
+++ b/api/models.py
@@ -248,6 +248,13 @@ class Node(DatabaseModel):
     holdoff: Optional[datetime] = Field(
         description="Node expiry timestamp while in Available state"
     )
+    owner: Optional[str] = Field(
+        description="Username of node owner"
+    )
+    user_groups: List[str] = Field(
+        default=[],
+        description="User groups that are permitted to update node"
+    )
 
     _OBJECT_ID_FIELDS = ['parent']
     _TIMESTAMP_FIELDS = ['created', 'updated', 'timeout', 'holdoff']

--- a/tests/e2e_tests/test_node_handler.py
+++ b/tests/e2e_tests/test_node_handler.py
@@ -35,6 +35,7 @@ async def create_node(test_async_client, node):
             'holdoff',
             'kind',
             'name',
+            'owner',
             'path',
             'parent',
             'result',
@@ -42,6 +43,7 @@ async def create_node(test_async_client, node):
             'state',
             'timeout',
             'updated',
+            'user_groups',
         }
     return response
 
@@ -70,6 +72,7 @@ async def get_node_by_id(test_async_client, node_id):
             'holdoff',
             'kind',
             'name',
+            'owner',
             'path',
             'parent',
             'result',
@@ -77,6 +80,7 @@ async def get_node_by_id(test_async_client, node_id):
             'state',
             'timeout',
             'updated',
+            'user_groups',
         }
     return response
 
@@ -133,6 +137,7 @@ async def update_node(test_async_client, node):
             'holdoff',
             'kind',
             'name',
+            'owner',
             'path',
             'parent',
             'result',
@@ -140,4 +145,5 @@ async def update_node(test_async_client, node):
             'state',
             'timeout',
             'updated',
+            'user_groups',
         }

--- a/tests/e2e_tests/test_regression_handler.py
+++ b/tests/e2e_tests/test_regression_handler.py
@@ -37,6 +37,7 @@ async def create_regression(test_async_client, regression_node):
             'holdoff',
             'kind',
             'name',
+            'owner',
             'path',
             'parent',
             'result',
@@ -45,6 +46,7 @@ async def create_regression(test_async_client, regression_node):
             'state',
             'timeout',
             'updated',
+            'user_groups',
         }
 
 

--- a/tests/unit_tests/test_node_handler.py
+++ b/tests/unit_tests/test_node_handler.py
@@ -79,6 +79,7 @@ def test_create_node_endpoint(mock_get_current_user, mock_init_sub_id,
         'holdoff',
         'kind',
         'name',
+        'owner',
         'path',
         'parent',
         'result',
@@ -86,6 +87,7 @@ def test_create_node_endpoint(mock_get_current_user, mock_init_sub_id,
         'state',
         'timeout',
         'updated',
+        'user_groups',
     }
 
 
@@ -231,6 +233,7 @@ def test_get_node_by_id_endpoint(mock_get_current_user, mock_db_find_by_id,
         'holdoff',
         'kind',
         'name',
+        'owner',
         'path',
         'parent',
         'result',
@@ -238,6 +241,7 @@ def test_get_node_by_id_endpoint(mock_get_current_user, mock_db_find_by_id,
         'state',
         'timeout',
         'updated',
+        'user_groups',
     }
 
 


### PR DESCRIPTION
Fixes https://github.com/kernelci/kernelci-api/issues/256

Add user ownership to nodes. 
- Add `Node.user_id` field to store user ID that created the node
- Added method to authorize user for PUT node requests
- Exclude `user_id` field from response data of node related requests i.e. GET, PUT, and POST