### PR TITLE
Remove  `User.is_admin` field

### DIFF
--- a/api/main.py
+++ b/api/main.py
@@ -214,7 +214,8 @@ async def login_for_access_token(
             )
 
     if 'admin' in form_data.scopes:
-        if user.is_admin is not True:
+        if not user.groups or not any(
+                group.name == 'admin' for group in user.groups):
             raise HTTPException(
                 status_code=status.HTTP_400_BAD_REQUEST,
                 detail="Not allowed to use admin scope"

--- a/api/main.py
+++ b/api/main.py
@@ -120,7 +120,7 @@ async def get_user(user: User = Depends(get_current_user)):
 @app.post('/user/{username}', response_model=User,
           response_model_by_alias=False)
 async def post_user(
-        username: str, password: Password, is_admin: bool = False,
+        username: str, password: Password,
         groups: List[str] = Query([]),
         current_user: User = Security(get_user, scopes=["admin"])):
     """Create new user"""
@@ -140,7 +140,6 @@ async def post_user(
         obj = await db.create(User(
                                 username=username,
                                 hashed_password=hashed_password,
-                                is_admin=is_admin,
                                 groups=group_obj
                                 ))
     except DuplicateKeyError as error:

--- a/api/models.py
+++ b/api/models.py
@@ -124,10 +124,6 @@ class User(DatabaseModel):
         default=True,
         description="To check if user is active or not"
     )
-    is_admin: bool = Field(
-        default=False,
-        description="True if superuser otherwise False"
-    )
     groups: List[UserGroup] = Field(
         default=[],
         description="A list of groups that user belongs to"

--- a/tests/e2e_tests/test_user_creation.py
+++ b/tests/e2e_tests/test_user_creation.py
@@ -40,7 +40,6 @@ async def test_create_admin_user(test_async_client):
         User(
             username=username,
             hashed_password=hashed_password,
-            is_admin=1,
             groups=[UserGroup(name="admin")]
         ))
     assert obj is not None
@@ -84,7 +83,7 @@ async def test_create_regular_user(test_async_client):
     )
     assert response.status_code == 200
     assert ('id', 'username', 'hashed_password', 'active',
-            'is_admin', 'groups') == tuple(response.json().keys())
+            'groups') == tuple(response.json().keys())
 
     response = await test_async_client.post(
         "token",
@@ -120,7 +119,7 @@ def test_whoami(test_client):
     )
     assert response.status_code == 200
     assert ('_id', 'username', 'hashed_password', 'active',
-            'is_admin', 'groups') == tuple(response.json().keys())
+            'groups') == tuple(response.json().keys())
     assert response.json()['username'] == 'test_user'
 
 

--- a/tests/unit_tests/conftest.py
+++ b/tests/unit_tests/conftest.py
@@ -115,7 +115,7 @@ def mock_get_current_user(mocker):
     user = User(username='bob',
                 hashed_password='$2b$12$CpJZx5ooxM11bCFXT76/z.o6HWs2sPJy4iP8.'
                                 'xCZGmM8jWXUXJZ4K',
-                active=True, is_admin=False)
+                active=True)
     mocker.patch('api.auth.Authentication.get_current_user',
                  side_effect=async_mock)
     async_mock.return_value = user, None
@@ -132,8 +132,7 @@ def mock_get_current_admin_user(mocker):
     user = User(username='admin',
                 hashed_password='$2b$12$CpJZx5ooxM11bCFXT76/z.o6HWs2sPJy4iP8.'
                                 'xCZGmM8jWXUXJZ4K',
-                active=True, is_admin=True, groups=[
-                    UserGroup(name='admin')])
+                active=True, groups=[UserGroup(name='admin')])
     mocker.patch('api.auth.Authentication.get_current_user',
                  side_effect=async_mock)
     async_mock.return_value = user, None

--- a/tests/unit_tests/test_token_handler.py
+++ b/tests/unit_tests/test_token_handler.py
@@ -79,7 +79,7 @@ def test_token_endpoint_admin_user(mock_db_find_one, mock_init_sub_id,
     user = User(username='test_admin',
                 hashed_password='$2b$12$CpJZx5ooxM11bCFXT76/z.o6HWs2sPJy4iP8.'
                                 'xCZGmM8jWXUXJZ4K',
-                active=True, is_admin=True, groups=[UserGroup(name='admin')])
+                active=True, groups=[UserGroup(name='admin')])
     mock_db_find_one.return_value = user
     response = test_client.post(
         "token",

--- a/tests/unit_tests/test_user_handler.py
+++ b/tests/unit_tests/test_user_handler.py
@@ -24,8 +24,8 @@ def test_create_regular_user(mock_init_sub_id, mock_get_current_admin_user,
     when requested with admin user's bearer token
     Expected Result :
         HTTP Response Code 200 OK
-        JSON with 'id', 'username', 'hashed_password'
-        'active', and 'is_admin' keys
+        JSON with 'id', 'username', 'hashed_password', and
+        'active' keys
     """
     user = User(username='test', hashed_password="$2b$12$Whi.dpTC.\
 HR5UHMdMFQeOe1eD4oXaP08oW7ogYqyiNziZYNdUHs8i", active=True)
@@ -42,7 +42,7 @@ HR5UHMdMFQeOe1eD4oXaP08oW7ogYqyiNziZYNdUHs8i", active=True)
     print(response.json())
     assert response.status_code == 200
     assert ('id', 'username', 'hashed_password', 'active',
-            'is_admin', 'groups') == tuple(response.json().keys())
+            'groups') == tuple(response.json().keys())
 
 
 def test_create_admin_user(  # pylint: disable=too-many-arguments
@@ -55,17 +55,17 @@ def test_create_admin_user(  # pylint: disable=too-many-arguments
     when requested with admin user's bearer token
     Expected Result :
         HTTP Response Code 200 OK
-        JSON with 'id', 'username', 'hashed_password'
-        'active', and 'is_admin' keys
+        JSON with 'id', 'username', 'hashed_password', and
+        'active' keys
     """
     user = User(username='test_admin', hashed_password="$2b$12$Whi.dpTC.\
-HR5UHMdMFQeOe1eD4oXaP08oW7ogYqyiNziZYNdUHs8i", active=True, is_admin=True,
+HR5UHMdMFQeOe1eD4oXaP08oW7ogYqyiNziZYNdUHs8i", active=True,
                 groups=[UserGroup(name='admin')])
     mock_db_create.return_value = user
     mock_db_find_one.return_value = UserGroup(name='admin')
 
     response = test_client.post(
-        "user/test_admin?groups=admin&is_admin=1",
+        "user/test_admin?groups=admin",
         headers={
             "Accept": "application/json",
             "Authorization": ADMIN_BEARER_TOKEN
@@ -75,7 +75,7 @@ HR5UHMdMFQeOe1eD4oXaP08oW7ogYqyiNziZYNdUHs8i", active=True, is_admin=True,
     print(response.json())
     assert response.status_code == 200
     assert ('id', 'username', 'hashed_password', 'active',
-            'is_admin', 'groups') == tuple(response.json().keys())
+            'groups') == tuple(response.json().keys())
 
 
 def test_create_user_endpoint_negative(mock_init_sub_id, mock_get_current_user,
@@ -113,7 +113,7 @@ def test_create_user_with_group(  # pylint: disable=too-many-arguments
     Expected Result :
         HTTP Response Code 200 OK
         JSON with 'id', 'username', 'hashed_password'
-        'active', 'groups' and 'is_admin' keys
+        'active', and 'groups' keys
     """
     user = User(username='test_admin', hashed_password="$2b$12$Whi.dpTC.\
 HR5UHMdMFQeOe1eD4oXaP08oW7ogYqyiNziZYNdUHs8i", active=True, is_admin=True,
@@ -132,4 +132,4 @@ HR5UHMdMFQeOe1eD4oXaP08oW7ogYqyiNziZYNdUHs8i", active=True, is_admin=True,
     print(response.json())
     assert response.status_code == 200
     assert ('id', 'username', 'hashed_password', 'active',
-            'is_admin', 'groups') == tuple(response.json().keys())
+            'groups') == tuple(response.json().keys())

--- a/tests/unit_tests/test_whoami_handler.py
+++ b/tests/unit_tests/test_whoami_handler.py
@@ -30,4 +30,4 @@ def test_whoami_endpoint(mock_get_current_user, mock_init_sub_id, test_client):
     )
     assert response.status_code == 200
     assert ('_id', 'username', 'hashed_password', 'active',
-            'is_admin', 'groups') == tuple(response.json().keys())
+            'groups') == tuple(response.json().keys())


### PR DESCRIPTION
Created on top of https://github.com/kernelci/kernelci-api/pull/266

Fixes https://github.com/kernelci/kernelci-api/issues/278

`User.is_admin` field was introduced to verify if the user is an admin user. Now we have a specific user group `admin` and all the admin users will be assigned to it. Instead of `is_admin` flag, we can use `User.groups` to check if the user belongs to the `admin` group and hence we can check if it is an admin user.
Thus, we can drop `User.is_admin` field now.