### PR TITLE
api.main: fix response model to not have alias for `/whoami`

### DIFF
--- a/api/main.py
+++ b/api/main.py
@@ -228,7 +228,7 @@ async def login_for_access_token(
     return {"access_token": access_token, "token_type": "bearer"}
 
 
-@app.get('/whoami', response_model=User)
+@app.get('/whoami', response_model=User, response_model_by_alias=False)
 async def whoami(current_user: User = Depends(get_user)):
     """Get current user information"""
     return current_user

--- a/tests/e2e_tests/test_user_creation.py
+++ b/tests/e2e_tests/test_user_creation.py
@@ -107,7 +107,7 @@ def test_whoami(test_client):
     Test Case : Test KernelCI API /whoami endpoint
     Expected Result :
         HTTP Response Code 200 OK
-        JSON with '_id', 'username', 'hashed_password'
+        JSON with 'id', 'username', 'hashed_password'
         and 'active' keys
     """
     response = test_client.get(
@@ -118,7 +118,7 @@ def test_whoami(test_client):
         },
     )
     assert response.status_code == 200
-    assert ('_id', 'username', 'hashed_password', 'active',
+    assert ('id', 'username', 'hashed_password', 'active',
             'groups') == tuple(response.json().keys())
     assert response.json()['username'] == 'test_user'
 

--- a/tests/unit_tests/test_whoami_handler.py
+++ b/tests/unit_tests/test_whoami_handler.py
@@ -18,7 +18,7 @@ def test_whoami_endpoint(mock_get_current_user, mock_init_sub_id, test_client):
     Test Case : Test KernelCI API /whoami endpoint
     Expected Result :
         HTTP Response Code 200 OK
-        JSON with '_id', 'username', 'hashed_password'
+        JSON with 'id', 'username', 'hashed_password'
         and 'active' keys
     """
     response = test_client.get(
@@ -29,5 +29,5 @@ def test_whoami_endpoint(mock_get_current_user, mock_init_sub_id, test_client):
         },
     )
     assert response.status_code == 200
-    assert ('_id', 'username', 'hashed_password', 'active',
+    assert ('id', 'username', 'hashed_password', 'active',
             'groups') == tuple(response.json().keys())


### PR DESCRIPTION
Use `response_model_by_alias` flag for `/whoami` endpoint to get response without alias. This is to fix `_id` field in the response.