### PR TITLE
Use a MongoDB service string rather than explicit host and port

### DIFF
--- a/api/db.py
+++ b/api/db.py
@@ -34,8 +34,8 @@ class Database:
         'gte': '$gte',
     }
 
-    def __init__(self, host='db', db_name='kernelci'):
-        self._motor = motor_asyncio.AsyncIOMotorClient(host=host)
+    def __init__(self, service='mongodb://db:27017', db_name='kernelci'):
+        self._motor = motor_asyncio.AsyncIOMotorClient(service)
         self._db = self._motor[db_name]
 
     def _get_collection(self, model):

--- a/api/main.py
+++ b/api/main.py
@@ -8,6 +8,7 @@
 
 """KernelCI API main module"""
 
+import os
 from typing import List, Union
 from fastapi import (
     Depends,
@@ -42,7 +43,7 @@ from .paginator_models import PageModel
 from .pubsub import PubSub, Subscription
 
 app = FastAPI()
-db = Database()
+db = Database(service=(os.getenv('MONGO_SERVICE') or 'mongodb://db:27017'))
 auth = Authentication(db, token_url='token',
                       user_scopes={"admin": "Superusers",
                                    "users": "Regular users"})


### PR DESCRIPTION
Use a `mongo://` kind of service string URL rather than a host and port to connect to a MongoDB instance.  Also look for a `MONGO_SERVICE` environment variable to load it if provided, which can contain a username and password.  This makes it possible to connect exactly the same way to the local instance in the `db` container or a remote Atlas instance.