### PR TITLE
api.models: apply unique items constraint to user groups

### DIFF
--- a/api/models.py
+++ b/api/models.py
@@ -21,6 +21,7 @@ from pydantic import (
     Field,
     FileUrl,
     SecretStr,
+    conlist,
 )
 
 
@@ -124,7 +125,7 @@ class User(DatabaseModel):
         default=True,
         description="To check if user is active or not"
     )
-    groups: List[UserGroup] = Field(
+    groups: conlist(UserGroup, unique_items=True) = Field(
         default=[],
         description="A list of groups that user belongs to"
     )


### PR DESCRIPTION
Fixes https://github.com/kernelci/kernelci-api/issues/283

To prevent duplicated user groups in `User.groups` list, use field type `conlist` from Pydantic.