### PR TITLE
docker-compose.yaml: set MongoDB cache to 0.5 GB

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -24,6 +24,7 @@ services:
   db:
     container_name: 'kernelci-api-db'
     image: 'mongo:5.0'
+    command: '--wiredTigerCacheSizeGB=0.5'
     ports:
       - '${MONGO_HOST_PORT:-8017}:27017'
     volumes:


### PR DESCRIPTION
Limit the MongoDB cache to 0.5 GB using the standard --wiredTigerCacheSizeGB command line argument.  The default value is to use 50% of the available RAM which is disproportionate for a regular development setup.