### PR TITLE
Update "Getting started" guide after setting up local environment

### DIFF
--- a/doc/getting-started.md
+++ b/doc/getting-started.md
@@ -125,7 +125,7 @@ For example, to check it's working:
 
 ```
 $ curl -X 'GET' \
-  'http://localhost:8001/latest/me' \
+  'http://localhost:8001/latest/whoami' \
   -H 'accept: application/json' \
   -H 'Authorization: Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJib2IifQ.KHkILtsJaCmueOfFCj79HGr6kHamuZFdB1Yz_5GqcC4'
 {"_id":"615f30020eb7c3c6616e5ac3","username":"bob","hashed_password":"$2b$12$VtfVij6zz20F/Qr0Ri18O.11.0LJMMXyJxAJAHQbKU0jC96eo2fr.","active":true}

--- a/doc/getting-started.md
+++ b/doc/getting-started.md
@@ -128,7 +128,7 @@ $ curl -X 'GET' \
   'http://localhost:8001/latest/whoami' \
   -H 'accept: application/json' \
   -H 'Authorization: Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJib2IifQ.KHkILtsJaCmueOfFCj79HGr6kHamuZFdB1Yz_5GqcC4'
-{"_id":"615f30020eb7c3c6616e5ac3","username":"bob","hashed_password":"$2b$12$VtfVij6zz20F/Qr0Ri18O.11.0LJMMXyJxAJAHQbKU0jC96eo2fr.","active":true}
+{"id":"615f30020eb7c3c6616e5ac3","username":"bob","hashed_password":"$2b$12$VtfVij6zz20F/Qr0Ri18O.11.0LJMMXyJxAJAHQbKU0jC96eo2fr.","active":true}
 ```
 
 ### Setup SSH keys

--- a/doc/getting-started.md
+++ b/doc/getting-started.md
@@ -23,6 +23,8 @@ clients are then handled using Docker images.
 
 This section covers how to set up a local API instance using the default
 self-contained configuration.  It doesn't rely on any external services.
+Commands from the sections below should be run within a directory containing
+[`kernelci-api`](https://github.com/kernelci/kernelci-api.git) repository.
 
 ### Create the environment file
 
@@ -196,6 +198,10 @@ environments such as Kubernetes LAVA, KCIDB credentials to send data etc.  On
 this page, we'll focus on the simple case with just a `docker-compose` API
 instance as described in the previous section and one instance for the
 pipeline.
+
+Commands from the sections below should be run within a directory containing
+[`kernelci-pipeline`](https://github.com/kernelci/kernelci-pipeline.git)
+repository.
 
 ### Configure the API token
 

--- a/doc/getting-started.md
+++ b/doc/getting-started.md
@@ -213,6 +213,11 @@ file which provides environment variables for the Docker containers:
 echo "KCI_API_TOKEN=<your token>" >> .env
 ```
 
+> **Note** Admin API token created in the previous section can be used for
+> initial Pipeline instance testing. In production environment the best
+> practice would be to create a separate (non-admin) user with required scopes
+> and generate a new API token for that user.
+
 ### Start docker-compose
 
 Then the pipeline can simply be started with docker-compose:


### PR DESCRIPTION
Endpoint "/me" was replaced with "/whoami" in:
ef045973cf72cc70bda8736c73e8a62609275ad4