### PR TITLE
Update `Node.owner` to be a mandatory field

### DIFF
--- a/api/main.py
+++ b/api/main.py
@@ -127,14 +127,13 @@ async def authorize_user(node_id: str, user: User = Depends(get_current_user)):
     # Only the user that created the node or any other user from the permitted
     # user groups will be allowed to update the node
     node_from_id = await db.find_by_id(Node, node_id)
-    if node_from_id.owner:
-        if not user.profile.username == node_from_id.owner:
-            if not any(group.name in node_from_id.user_groups
-                       for group in user.profile.groups):
-                raise HTTPException(
-                    status_code=status.HTTP_401_UNAUTHORIZED,
-                    detail="Unauthorized to complete the operation"
-                )
+    if not user.profile.username == node_from_id.owner:
+        if not any(group.name in node_from_id.user_groups
+                   for group in user.groups):
+            raise HTTPException(
+                status_code=status.HTTP_401_UNAUTHORIZED,
+                detail="Unauthorized to complete the operation"
+            )
     return user
 
 


### PR DESCRIPTION
Remove `Optional` and make `Node.owner` a mandatory field. `Optional` was added as node ownership fields were not
present previously. Not marking the field `Optional` could have led to an issue for existing nodes on staging instance.
Update `authorize_user` method accordingly.