### PR TITLE
docker/api/requirements: fix `api` container build failure

### DIFF
--- a/api/main.py
+++ b/api/main.py
@@ -291,7 +291,7 @@ async def translate_null_query_params(query_params: dict):
     return translated
 
 
-@app.get('/node/{node_id}', response_model=Union[Regression, Node],
+@app.get('/node/{node_id}', response_model=Union[Regression, Node, None],
          response_model_by_alias=False)
 async def get_node(node_id: str, kind: str = "node"):
     """Get node information from the provided node id"""

--- a/docker/api/requirements.txt
+++ b/docker/api/requirements.txt
@@ -1,6 +1,6 @@
 aioredis[hiredis]==2.0.0
 cloudevents==1.9.0
-fastapi[all]==0.68.1
+fastapi[all]==0.99.1
 fastapi-pagination==0.9.3
 passlib==1.7.4
 pydantic==1.10.5

--- a/tests/e2e_tests/conftest.py
+++ b/tests/e2e_tests/conftest.py
@@ -10,8 +10,6 @@ import pytest
 from httpx import AsyncClient
 from motor.motor_asyncio import AsyncIOMotorClient
 
-from fastapi.testclient import TestClient
-
 from api.main import app
 
 BASE_URL = 'http://api:8000/latest/'
@@ -20,13 +18,6 @@ DB_NAME = 'kernelci'
 
 db_client = AsyncIOMotorClient(DB_URL)
 db = db_client[DB_NAME]
-
-
-@pytest.fixture(scope='session')
-def test_client():
-    """Fixture to get FastAPI Test client instance"""
-    with TestClient(app=app, base_url=BASE_URL) as client:
-        yield client
 
 
 @pytest.fixture(scope='session')

--- a/tests/e2e_tests/test_count_handler.py
+++ b/tests/e2e_tests/test_count_handler.py
@@ -10,33 +10,35 @@
 import pytest
 
 
+@pytest.mark.asyncio
 @pytest.mark.dependency(
     depends=[
         'e2e_tests/test_pipeline.py::test_node_pipeline'],
     scope='session')
-def test_count_nodes(test_client):
+async def test_count_nodes(test_async_client):
     """
     Test Case : Test KernelCI API GET /count endpoint
     Expected Result :
         HTTP Response Code 200 OK
         Total number of nodes available
     """
-    response = test_client.get("count")
+    response = await test_async_client.get("count")
     assert response.status_code == 200
     assert response.json() >= 0
 
 
+@pytest.mark.asyncio
 @pytest.mark.dependency(
     depends=[
         'e2e_tests/test_pipeline.py::test_node_pipeline'],
     scope='session')
-def test_count_nodes_matching_attributes(test_client):
+async def test_count_nodes_matching_attributes(test_async_client):
     """
     Test Case : Test KernelCI API GET /count endpoint with attributes
     Expected Result :
         HTTP Response Code 200 OK
         Number of nodes matching attributes
     """
-    response = test_client.get("count?name=checkout")
+    response = await test_async_client.get("count?name=checkout")
     assert response.status_code == 200
     assert response.json() >= 0

--- a/tests/e2e_tests/test_root_handler.py
+++ b/tests/e2e_tests/test_root_handler.py
@@ -5,9 +5,12 @@
 
 """End-to-end test functions for KernelCI API root handler"""
 
+import pytest
 
-def test_root_endpoint(test_client):
+
+@pytest.mark.asyncio
+async def test_root_endpoint(test_async_client):
     """Test root handler"""
-    response = test_client.get("/latest")
+    response = await test_async_client.get("/")
     assert response.status_code == 200
     assert response.json() == {"message": "KernelCI API"}

--- a/tests/e2e_tests/test_subscribe_handler.py
+++ b/tests/e2e_tests/test_subscribe_handler.py
@@ -9,18 +9,19 @@
 import pytest
 
 
+@pytest.mark.asyncio
 @pytest.mark.dependency(
     depends=['e2e_tests/test_user_creation.py::test_create_regular_user'],
     scope='session')
 @pytest.mark.order(4)
-def test_subscribe_node_channel(test_client):
+async def test_subscribe_node_channel(test_async_client):
     """
     Test Case : Test KernelCI API '/subscribe' endpoint with 'node' channel
     Expected Result :
         HTTP Response Code 200 OK
         JSON with subscription 'id' and 'channel' keys
     """
-    response = test_client.post(
+    response = await test_async_client.post(
         "subscribe/node",
         headers={
             "Authorization": f"Bearer {pytest.BEARER_TOKEN}"
@@ -32,18 +33,19 @@ def test_subscribe_node_channel(test_client):
     assert response.json().get('channel') == 'node'
 
 
+@pytest.mark.asyncio
 @pytest.mark.dependency(
     depends=['e2e_tests/test_user_creation.py::test_create_regular_user'],
     scope='session')
 @pytest.mark.order(4)
-def test_subscribe_test_channel(test_client):
+async def test_subscribe_test_channel(test_async_client):
     """
     Test Case : Test KernelCI API '/subscribe' endpoint with 'test_channel'
     Expected Result :
         HTTP Response Code 200 OK
         JSON with subscription 'id' and 'channel' keys
     """
-    response = test_client.post(
+    response = await test_async_client.post(
         "subscribe/test_channel",
         headers={
             "Authorization": f"Bearer {pytest.BEARER_TOKEN}"

--- a/tests/e2e_tests/test_unsubscribe_handler.py
+++ b/tests/e2e_tests/test_unsubscribe_handler.py
@@ -9,18 +9,19 @@
 import pytest
 
 
+@pytest.mark.asyncio
 @pytest.mark.dependency(
     depends=[
         'e2e_tests/test_subscribe_handler.py::test_subscribe_node_channel'],
     scope='session')
 @pytest.mark.order("last")
-def test_unsubscribe_node_channel(test_client):
+async def test_unsubscribe_node_channel(test_async_client):
     """
     Test Case : Test KernelCI API '/unsubscribe' endpoint with 'node' channel
     Expected Result :
         HTTP Response Code 200 OK
     """
-    response = test_client.post(
+    response = await test_async_client.post(
         f"unsubscribe/{pytest.node_channel_subscription_id}",
         headers={
             "Authorization": f"Bearer {pytest.BEARER_TOKEN}"
@@ -29,18 +30,19 @@ def test_unsubscribe_node_channel(test_client):
     assert response.status_code == 200
 
 
+@pytest.mark.asyncio
 @pytest.mark.dependency(
     depends=[
         'e2e_tests/test_subscribe_handler.py::test_subscribe_test_channel'],
     scope='session')
 @pytest.mark.order("last")
-def test_unsubscribe_test_channel(test_client):
+async def test_unsubscribe_test_channel(test_async_client):
     """
     Test Case : Test KernelCI API '/unsubscribe' endpoint with 'test_channel'
     Expected Result :
         HTTP Response Code 200 OK
     """
-    response = test_client.post(
+    response = await test_async_client.post(
         f"unsubscribe/{pytest.test_channel_subscription_id}",
         headers={
             "Authorization": f"Bearer {pytest.BEARER_TOKEN}"

--- a/tests/e2e_tests/test_user_creation.py
+++ b/tests/e2e_tests/test_user_creation.py
@@ -105,8 +105,9 @@ async def test_create_regular_user(test_async_client):
     pytest.BEARER_TOKEN = response.json()['access_token']
 
 
+@pytest.mark.asyncio
 @pytest.mark.dependency(depends=["test_create_regular_user"])
-def test_whoami(test_client):
+async def test_whoami(test_async_client):
     """
     Test Case : Test KernelCI API /whoami endpoint
     Expected Result :
@@ -114,7 +115,7 @@ def test_whoami(test_client):
         JSON with 'id', 'username', 'hashed_password'
         and 'active' keys
     """
-    response = test_client.get(
+    response = await test_async_client.get(
         "whoami",
         headers={
             "Accept": "application/json",
@@ -129,8 +130,9 @@ def test_whoami(test_client):
     assert response.json()['profile']['username'] == 'test_user'
 
 
+@pytest.mark.asyncio
 @pytest.mark.dependency(depends=["test_create_regular_user"])
-def test_create_user_negative(test_client):
+async def test_create_user_negative(test_async_client):
     """
     Test Case : Test KernelCI API /user endpoint when requested
     with regular user's bearer token.
@@ -138,7 +140,7 @@ def test_create_user_negative(test_client):
         HTTP Response Code 401 Unauthorized
         JSON with 'detail' key denoting 'Access denied' error
     """
-    response = test_client.post(
+    response = await test_async_client.post(
         "user/test",
         headers={
                 "Accept": "application/json",


### PR DESCRIPTION
Fixes https://github.com/kernelci/kernelci-api/issues/303

Fix build failures of `api` container. Error logs can be found at ```https://github.com/kernelci/kernelci-api/issues/303```.

Root cause:
`fastapi[all] 0.68.1` package installs `pyyaml 5.4.1` package internally. That again depends on `CPython` package. Due to the recent upgrade to `CPython 3.0.0`, `pyyaml 5.4.1` stopped building with `python 3.10`. To fix this, upgrading `fastapi[all]` to `0.99.1` version as that uses `pyyaml 6.0.1`. The selected `fastapi` version is compatible with current `fastapi-pagination` and `fastapi-versioning` packages.