### PR TITLE
docker/api: pin PyYAML version to 5.3.1

### DIFF
--- a/docker/api/requirements.txt
+++ b/docker/api/requirements.txt
@@ -8,4 +8,5 @@ python-jose[cryptography]==3.3.0
 uvicorn[standard]==0.13.4
 motor==2.5.1
 pymongo-migrate==0.11.0
+pyyaml==5.3.1
 fastapi-versioning==0.10.0


### PR DESCRIPTION
The version of PyYAML was not being specified and newer releases rely on more recent dependencies which cascade into basically updating FastAPI and some parts of the code accordingly.  While doing this would make sense to keep the API codebase up-to-date, pin down the PyYAML version to 5.3.1 for now in requirements.txt so we avoid the whole issue in the short term.

Fixes: https://github.com/kernelci/kernelci-api/issues/303