### PR TITLE
api.main: fix user.profiles.groups in authorize_user()

### DIFF
--- a/api/main.py
+++ b/api/main.py
@@ -129,7 +129,7 @@ async def authorize_user(node_id: str, user: User = Depends(get_current_user)):
     node_from_id = await db.find_by_id(Node, node_id)
     if not user.profile.username == node_from_id.owner:
         if not any(group.name in node_from_id.user_groups
-                   for group in user.groups):
+                   for group in user.profile.groups):
             raise HTTPException(
                 status_code=status.HTTP_401_UNAUTHORIZED,
                 detail="Unauthorized to complete the operation"


### PR DESCRIPTION
Fix how the authorize_user() function is checking if the node's group matches the user's groups as they're now in user.profile.groups.

Fixes: 73c1d5797653 ("api.main: drop a check for node owner in `authorize_user`")