### PR TITLE
api.pubsub: enable keep-alive with 45s default period

### DIFF
--- a/api/pubsub.py
+++ b/api/pubsub.py
@@ -17,7 +17,7 @@ class Settings(BaseSettings):
     cloud_events_source: str = "https://api.kernelci.org/"
     redis_host: str = "redis"
     redis_db_number: int = 1
-    keep_alive_period: int = 0
+    keep_alive_period: int = 45
 
 
 class Subscription(BaseModel):

--- a/test-docker-compose.yaml
+++ b/test-docker-compose.yaml
@@ -61,3 +61,5 @@ services:
       - api
     env_file:
       - '.env'
+    environment:
+      - 'KEEP_ALIVE_PERIOD=0'

--- a/tests/e2e_tests/test_pipeline.py
+++ b/tests/e2e_tests/test_pipeline.py
@@ -58,6 +58,7 @@ async def test_node_pipeline(test_async_client):
     # Get result of pubsub event listen task
     await task_listen
     event_data = from_json(task_listen.result().json().get('data')).data
+    assert event_data != 'BEEP'
     keys = {'op', 'id', 'name', 'path', 'group', 'state', 'result', 'revision'}
     assert keys == event_data.keys()
     assert event_data.get('op') == 'created'
@@ -79,6 +80,7 @@ async def test_node_pipeline(test_async_client):
     # Get result of pubsub event listen task
     await task_listen
     event_data = from_json(task_listen.result().json().get('data')).data
+    assert event_data != 'BEEP'
     keys = {'op', 'id', 'name', 'path', 'group', 'state', 'result', 'revision'}
     assert keys == event_data.keys()
     assert event_data.get('op') == 'updated'

--- a/tests/e2e_tests/test_pubsub_handler.py
+++ b/tests/e2e_tests/test_pubsub_handler.py
@@ -51,5 +51,6 @@ async def test_pubsub_handler(test_async_client):
         'type',
     }
     event_data = from_json(task_listen.result().json().get('data')).data
+    assert event_data != 'BEEP'
     assert ('message',) == tuple(event_data.keys())
     assert event_data.get('message') == 'Test message'


### PR DESCRIPTION
The keep-alive feature has now become necessary even for local docker-compose setups as the client code has a default timeout of 60s. Enable it with a default period of 45s to avoid this issue, which should also avoid hitting infrastructure errors which were the original reason for adding the keep-alive feature.

Fixes: https://github.com/kernelci/kernelci-pipeline/issues/290