### PR TITLE
Add email field to user profile

### DIFF
--- a/api/admin.py
+++ b/api/admin.py
@@ -28,7 +28,7 @@ async def setup_admin_group(db, admin_group):
     return group_obj
 
 
-async def setup_admin_user(db, username, admin_group):
+async def setup_admin_user(db, username, email, admin_group):
     user_obj = await db.find_one_by_attributes(User,
                                                {'profile.username': username})
     if user_obj:
@@ -41,6 +41,7 @@ async def setup_admin_user(db, username, admin_group):
     profile = UserProfile(
         username=username,
         hashed_password=hashed_password,
+        email=email,
         groups=[admin_group]
     )
     return await db.create(User(
@@ -51,7 +52,7 @@ async def setup_admin_user(db, username, admin_group):
 async def main(args):
     db = Database(args.mongo, args.database)
     group = await setup_admin_group(db, args.admin_group)
-    user = await setup_admin_user(db, args.username, group)
+    user = await setup_admin_user(db, args.username, args.email, group)
     return True
 
 
@@ -65,5 +66,7 @@ if __name__ == '__main__':
                         help="Admin group name")
     parser.add_argument('--database', default='kernelci',
                         help="KernelCI database name")
+    parser.add_argument('--email', required=True,
+                        help="Admin user email address")
     args = parser.parse_args()
     sys.exit(0 if asyncio.run(main(args)) else 1)

--- a/api/models.py
+++ b/api/models.py
@@ -18,10 +18,11 @@ from pydantic import (
     AnyHttpUrl,
     AnyUrl,
     BaseModel,
+    conlist,
+    EmailStr,
     Field,
     FileUrl,
     SecretStr,
-    conlist,
 )
 
 
@@ -124,6 +125,9 @@ class UserProfile(BaseModel):
     groups: conlist(UserGroup, unique_items=True) = Field(
         default=[],
         description="A list of groups that user belongs to"
+    )
+    email: EmailStr = Field(
+        description="User email address"
     )
 
 

--- a/tests/e2e_tests/test_user_creation.py
+++ b/tests/e2e_tests/test_user_creation.py
@@ -38,6 +38,7 @@ async def test_create_admin_user(test_async_client):
     profile = UserProfile(
         username=username,
         hashed_password=hashed_password,
+        email='test-admin@kernelci.org',
         groups=[UserGroup(name="admin")]
     )
     obj = await db_create(
@@ -75,8 +76,9 @@ async def test_create_regular_user(test_async_client):
     """
     username = 'test_user'
     password = 'test'
+    email = 'test@kernelci.org'
     response = await test_async_client.post(
-        f"user/{username}",
+        f"user/{username}?email={email}",
         headers={
                 "Accept": "application/json",
                 "Authorization": f"Bearer {pytest.ADMIN_BEARER_TOKEN}"
@@ -87,7 +89,7 @@ async def test_create_regular_user(test_async_client):
     assert ('id', 'active',
             'profile') == tuple(response.json().keys())
     assert ('username', 'hashed_password',
-            'groups') == tuple(response.json()['profile'].keys())
+            'groups', 'email') == tuple(response.json()['profile'].keys())
 
     response = await test_async_client.post(
         "token",
@@ -125,7 +127,7 @@ def test_whoami(test_client):
     assert ('id', 'active',
             'profile') == tuple(response.json().keys())
     assert ('username', 'hashed_password',
-            'groups') == tuple(response.json()['profile'].keys())
+            'groups', 'email') == tuple(response.json()['profile'].keys())
     assert response.json()['profile']['username'] == 'test_user'
 
 

--- a/tests/unit_tests/conftest.py
+++ b/tests/unit_tests/conftest.py
@@ -128,6 +128,7 @@ def mock_get_current_user(mocker):
         username='bob',
         hashed_password='$2b$12$CpJZx5ooxM11bCFXT76/z.o6HWs2sPJy4iP8.'
                         'xCZGmM8jWXUXJZ4K',
+        email='bob@kernelci.org'
     )
     user = User(profile=profile, active=True)
     mocker.patch('api.auth.Authentication.get_current_user',
@@ -147,6 +148,7 @@ def mock_get_current_admin_user(mocker):
         username='admin',
         hashed_password='$2b$12$CpJZx5ooxM11bCFXT76/z.o6HWs2sPJy4iP8.'
                         'xCZGmM8jWXUXJZ4K',
+        email='admin@kernelci.org',
         groups=[UserGroup(name='admin')])
     user = User(
         profile=profile,

--- a/tests/unit_tests/test_token_handler.py
+++ b/tests/unit_tests/test_token_handler.py
@@ -25,6 +25,7 @@ def test_token_endpoint(mock_db_find_one_by_attributes,
         username='bob',
         hashed_password='$2b$12$CpJZx5ooxM11bCFXT76/z.o6HWs2sPJy4iP8.'
                         'xCZGmM8jWXUXJZ4K',
+        email='bob@kernelci.org',
         groups=[]
     )
     user = User(profile=profile, active=True)
@@ -57,6 +58,7 @@ def test_token_endpoint_incorrect_password(mock_db_find_one_by_attributes,
         username='bob',
         hashed_password='$2b$12$CpJZx5ooxM11bCFXT76/z.o6HWs2sPJy4iP8.'
                         'xCZGmM8jWXUXJZ4K',
+        email='bob@kernelci.org',
         groups=[])
     user = User(profile=profile, active=True)
     mock_db_find_one_by_attributes.return_value = user
@@ -88,6 +90,7 @@ def test_token_endpoint_admin_user(mock_db_find_one_by_attributes,
         username='test_admin',
         hashed_password='$2b$12$CpJZx5ooxM11bCFXT76/z.o6HWs2sPJy4iP8.'
                         'xCZGmM8jWXUXJZ4K',
+        email='test-admin@kernelci.org',
         groups=[UserGroup(name='admin')])
     user = User(profile=profile, active=True)
     mock_db_find_one_by_attributes.return_value = user

--- a/tests/unit_tests/test_user_handler.py
+++ b/tests/unit_tests/test_user_handler.py
@@ -28,12 +28,12 @@ def test_create_regular_user(mock_init_sub_id, mock_get_current_admin_user,
         'active' keys
     """
     profile = UserProfile(username='test', hashed_password="$2b$12$Whi.dpTC.\
-HR5UHMdMFQeOe1eD4oXaP08oW7ogYqyiNziZYNdUHs8i")
+HR5UHMdMFQeOe1eD4oXaP08oW7ogYqyiNziZYNdUHs8i", email='test@kernelci.org')
     user = User(profile=profile, active=True)
     mock_db_create.return_value = user
 
     response = test_client.post(
-        "user/test",
+        "user/test?email=test@kernelci.org",
         headers={
             "Accept": "application/json",
             "Authorization": ADMIN_BEARER_TOKEN
@@ -44,7 +44,7 @@ HR5UHMdMFQeOe1eD4oXaP08oW7ogYqyiNziZYNdUHs8i")
     assert response.status_code == 200
     assert ('id', 'active', 'profile') == tuple(response.json().keys())
     assert ('username', 'hashed_password',
-            'groups') == tuple(response.json()['profile'].keys())
+            'groups', 'email') == tuple(response.json()['profile'].keys())
 
 
 def test_create_admin_user(  # pylint: disable=too-many-arguments
@@ -64,13 +64,14 @@ def test_create_admin_user(  # pylint: disable=too-many-arguments
         username='test_admin',
         hashed_password="$2b$12$Whi.dpTC.HR5UHMdMFQeOe1eD4oXaP08o\
 W7ogYqyiNziZYNdUHs8i",
+        email='test-admin@kernelci.org',
         groups=[UserGroup(name='admin')])
     user = User(profile=profile, active=True)
     mock_db_create.return_value = user
     mock_db_find_one.return_value = UserGroup(name='admin')
 
     response = test_client.post(
-        "user/test_admin?groups=admin",
+        "user/test_admin?groups=admin&email=test-admin@kernelci.org",
         headers={
             "Accept": "application/json",
             "Authorization": ADMIN_BEARER_TOKEN
@@ -81,7 +82,7 @@ W7ogYqyiNziZYNdUHs8i",
     assert response.status_code == 200
     assert ('id', 'active', 'profile') == tuple(response.json().keys())
     assert ('username', 'hashed_password',
-            'groups') == tuple(response.json()['profile'].keys())
+            'groups', 'email') == tuple(response.json()['profile'].keys())
 
 
 def test_create_user_endpoint_negative(mock_init_sub_id, mock_get_current_user,
@@ -125,13 +126,14 @@ def test_create_user_with_group(  # pylint: disable=too-many-arguments
         username='test_admin',
         hashed_password="$2b$12$Whi.dpTC.HR5UHMdMFQeOe1eD4oXaP08oW7\
 ogYqyiNziZYNdUHs8i",
+        email='test-admin@kernelci.org',
         groups=[UserGroup(name='kernelci')])
     user = User(profile=profile, active=True)
     mock_db_create.return_value = user
     mock_db_find_one.return_value = UserGroup(name='kernelci')
 
     response = test_client.post(
-        "user/test_admin?groups=kernelci",
+        "user/test_admin?groups=kernelci&email=test-admin@kernelci.org",
         headers={
             "Accept": "application/json",
             "Authorization": ADMIN_BEARER_TOKEN
@@ -142,4 +144,4 @@ ogYqyiNziZYNdUHs8i",
     assert response.status_code == 200
     assert ('id', 'active', 'profile') == tuple(response.json().keys())
     assert ('username', 'hashed_password',
-            'groups') == tuple(response.json()['profile'].keys())
+            'groups', 'email') == tuple(response.json()['profile'].keys())


### PR DESCRIPTION
Add `UserProfile.email` field to store user's email address. Update POST and PUT user handlers accordingly.
Also, update script to setup admin user to get admin email address.