### PR TITLE
e2e tests for user group handler

### DIFF
--- a/tests/e2e_tests/test_subscribe_handler.py
+++ b/tests/e2e_tests/test_subscribe_handler.py
@@ -53,3 +53,27 @@ def test_subscribe_test_channel(test_client):
     assert response.status_code == 200
     assert ('id', 'channel') == tuple(response.json().keys())
     assert response.json().get('channel') == 'test_channel'
+
+
+@pytest.mark.dependency(
+    depends=['e2e_tests/test_user_creation.py::test_create_regular_user'],
+    scope='session')
+@pytest.mark.order(4)
+def test_subscribe_user_group_channel(test_client):
+    """
+    Test Case : Test KernelCI API '/subscribe' endpoint with 'user_group'
+    channel
+    Expected Result :
+        HTTP Response Code 200 OK
+        JSON with subscription 'id' and 'channel' keys
+    """
+    response = test_client.post(
+        "subscribe/user_group",
+        headers={
+            "Authorization": f"Bearer {pytest.BEARER_TOKEN}"
+        },
+    )
+    pytest.user_group_channel_subscription_id = response.json()['id']
+    assert response.status_code == 200
+    assert ('id', 'channel') == tuple(response.json().keys())
+    assert response.json().get('channel') == 'user_group'

--- a/tests/e2e_tests/test_user_creation.py
+++ b/tests/e2e_tests/test_user_creation.py
@@ -14,7 +14,7 @@ from e2e_tests.conftest import db_create
 
 
 @pytest.mark.dependency(
-    depends=["e2e_tests/test_user_group_creation.py::test_create_user_groups"],
+    depends=["e2e_tests/test_user_group_handler.py::test_create_user_groups"],
     scope="session")
 @pytest.mark.dependency()
 @pytest.mark.order(2)

--- a/tests/e2e_tests/test_user_group_creation.py
+++ b/tests/e2e_tests/test_user_group_creation.py
@@ -25,3 +25,28 @@ async def test_create_user_groups():
             Database.COLLECTIONS[UserGroup],
             UserGroup(name=group))
         assert obj is not None
+
+
+@pytest.mark.dependency(
+    depends=["test_create_user_groups"])
+@pytest.mark.asyncio
+async def test_get_user_group(test_async_client):
+    """
+    Test Case : Get user groups
+    Expected Result :
+        HTTP Response Code 200 OK
+        Returns dictionary with UserGroup objects, total number of groups
+        returned along with limit and offset values
+    """
+    response = await test_async_client.get(
+        "groups",
+    )
+    assert response.status_code == 200
+    assert response.json().keys() == {
+            'items',
+            'total',
+            'limit',
+            'offset',
+        }
+    assert response.json()['total'] == 1
+    assert response.json()['items'][0]['name'] == 'admin'

--- a/tests/e2e_tests/test_user_group_handler.py
+++ b/tests/e2e_tests/test_user_group_handler.py
@@ -3,7 +3,7 @@
 # Copyright (C) 2023 Collabora Limited
 # Author: Jeny Sadadia <jeny.sadadia@collabora.com>
 
-"""End-to-end test functions for KernelCI API user group creation"""
+"""End-to-end test functions for KernelCI API user group handler"""
 
 import pytest
 

--- a/tests/e2e_tests/test_user_group_handler.py
+++ b/tests/e2e_tests/test_user_group_handler.py
@@ -6,10 +6,13 @@
 """End-to-end test functions for KernelCI API user group handler"""
 
 import pytest
+from cloudevents.http import from_json
+import json
 
 from api.models import UserGroup
 from api.db import Database
 from e2e_tests.conftest import db_create
+from .listen_handler import create_listen_task
 
 
 @pytest.mark.dependency()
@@ -50,3 +53,52 @@ async def test_get_user_group(test_async_client):
         }
     assert response.json()['total'] == 1
     assert response.json()['items'][0]['name'] == 'admin'
+
+
+@pytest.mark.dependency(
+    depends=[
+        'e2e_tests/test_subscribe_handler.py::test_subscribe_user_group_channel'],
+    scope='session')
+@pytest.mark.asyncio
+async def test_create_and_get_user_group(test_async_client):
+    """
+    Test Case : Create and get a user group by ID
+
+    At first, the test will create asyncio 'Task' instance to receive
+    pubsub events from 'user_group' channel.
+    A user group with name 'kernelci' will be created using POST '/group'
+    request. The 'created' event will be received from the listener task.
+    The GET '/group/{group_id}' will be sent using group id from event data
+    to get newly created user group object.
+    """
+    
+    # Create Task to listen pubsub event on 'user_group' channel
+    task_listen = create_listen_task(test_async_client,
+                                     pytest.user_group_channel_subscription_id)
+    
+    # Create a user group
+    response = await test_async_client.post(
+        "group",
+        headers={
+            "Accept": "application/json",
+            "Authorization": f"Bearer {pytest.ADMIN_BEARER_TOKEN}"
+        },
+        data=json.dumps({"name": "kernelci"})
+    )
+    assert response.status_code == 200
+    assert response.json().keys() == {
+        'id',
+        'name',
+    }
+
+    # Get result from the event
+    await task_listen
+    event_data = from_json(task_listen.result().json().get('data')).data
+    assert {'op', 'id'} == event_data.keys()
+
+    # Get user group by ID
+    response = await test_async_client.get(
+        f"group/{event_data['id']}"
+    )
+    assert response.status_code == 200
+    assert response.json()['name'] == 'kernelci'


### PR DESCRIPTION
Fixes https://github.com/kernelci/kernelci-api/issues/289

Implement end-to-end tests for user group handlers.
It includes testing of POST and GET '/group' handlers.