### PR TITLE
k8s: script to setup admin user

### DIFF
--- a/kube/minikube/scripts/setup_admin_user.sh
+++ b/kube/minikube/scripts/setup_admin_user.sh
@@ -1,0 +1,2 @@
+API_POD_NAME=$(kubectl get ep kernelci-api -o=jsonpath='{.subsets[*].addresses[*].ip}' | tr ' ' '\n' | xargs -I % kubectl get pods -o=name --field-selector=status.podIP=%)
+kubectl exec -it $API_POD_NAME -- python3 -m api.admin --mongo mongodb://kernelci-api-db.default.svc.cluster.local:27017 --email bot@kernelci.org


### PR DESCRIPTION
Added a script `kube/minikube/scripts/setup_admin_user.sh` to setup an admin user for k8s API instance.
At first, the script will get the pod name of `kernelci-api` service running on Minikube. Then it will run `api.admin` module inside the pod container to create an admin user. 