### PR TITLE
pyproject.toml: add initial file

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,34 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+#
+# Copyright (C) 2023 Collabora Limited
+# Author: Guillaume Tucker <guillaume.tucker@collabora.com>
+
+[project]
+name = "kernelci-api"
+version = "0"
+description = "KernelCI API"
+readme = "README.md"
+requires-python = ">=3.10"
+license = {text = "LGPL-2.1-or-later"}
+dependencies = [
+  "aioredis[hiredis] == 2.0.0",
+  "cloudevents == 1.9.0",
+  "fastapi[all] == 0.68.1",
+  "fastapi-pagination == 0.9.3",
+  "passlib == 1.7.4",
+  "pydantic == 1.10.5",
+  "python-jose[cryptography] == 3.3.0",
+  "uvicorn[standard] == 0.13.4",
+  "motor == 2.5.1",
+  "pymongo-migrate == 0.11.0",
+  "pyyaml == 5.3.1",
+  "fastapi-versioning == 0.10.0",
+]
+
+[project.urls]
+Homepage = "https://kernelci.org"
+Documentation = "https://kernelci.org/docs"
+Repository = "https://github.com/kernelci/kernelci-api"
+
+[tool.setuptools]
+packages = ["api"]


### PR DESCRIPTION
    Add an initial pyproject.toml file to be able to build and install the
    api Python package.
    
    Thanks to Nikolay Yurin for finding the bug about the license file:
    https://github.com/pypa/pip/issues/12251
    
    This project uses a standard license so it's better to just rely on
    the LGPL-2.1-or-later SPDX indentifier instead of providing the path
    to the whole license file.
    
    Development dependencies have been omitted and all the required
    dependencies have a fixed version in order to build reproducible
    Docker images for production deployment.  Some follow-up changes can
    be made to have a better way to handle dependencies for development.
