### PR TITLE
docker/api: add Dockerfile.production

### DIFF
--- a/docker/api/Dockerfile.production
+++ b/docker/api/Dockerfile.production
@@ -1,0 +1,25 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+#
+# Copyright (C) 2023 Collabora Limited
+# Author: Guillaume Tucker <guillaume.tucker@collabora.com>
+
+FROM python:3.10
+MAINTAINER "KernelCI TSC" <kernelci-tsc@groups.io>
+
+# Upgrade pip3 - never mind the warning about running this as root
+RUN pip3 install --upgrade "pip==23.2.1"
+
+# Upgrade setuptools for full pyproject.toml support
+RUN pip3 install "setuptools==68.1.2"
+
+# Create kernelci user
+RUN useradd kernelci -u 1000 -d /home/kernelci -s /bin/bash
+RUN mkdir -p /home/kernelci
+RUN chown kernelci: /home/kernelci
+USER kernelci
+ENV PATH=$PATH:/home/kernelci/.local/bin
+WORKDIR /home/kernelci
+
+ARG api_url=https://github.com/kernelci/kernelci-api.git
+ARG api_rev=main
+RUN pip install git+$api_url@$api_rev


### PR DESCRIPTION
Add Dockerfile.production to build the kernelci/api Docker image for production deployment.  It installs the "api" package using pip directly in the image so it's self-contained.  This relies on pyproject.toml to be set up correctly.

This is an alternative to the standard Dockerfile used by docker-compose for a local deployment based directly on the source tree.

Depends on https://github.com/kernelci/kernelci-api/pull/328