### PR TITLE
kube/minikube: fix Sanskar Bhushan copyright statements

### DIFF
--- a/kube/minkube/api-deployment.yaml
+++ b/kube/minkube/api-deployment.yaml
@@ -1,7 +1,6 @@
 # SPDX-License-Identifier: LGPL-2.1-or-later
 #
-# Copyright (C) 2023 KernelCI Authors.
-# Author: Sanskar Bhushan <sbdtu5498@gmail.com>
+# Copyright (C) 2023 Sanskar Bhushan <sbdtu5498@gmail.com>
 
 apiVersion: apps/v1
 kind: Deployment

--- a/kube/minkube/deployments/db-deployment.yaml
+++ b/kube/minkube/deployments/db-deployment.yaml
@@ -1,7 +1,6 @@
 # SPDX-License-Identifier: LGPL-2.1-or-later
 #
-# Copyright (C) 2023 KernelCI Authors.
-# Author: Sanskar Bhushan <sbdtu5498@gmail.com>
+# Copyright (C) 2023 Sanskar Bhushan <sbdtu5498@gmail.com>
 
 apiVersion: apps/v1
 kind: Deployment

--- a/kube/minkube/deployments/redis-deployment.yaml
+++ b/kube/minkube/deployments/redis-deployment.yaml
@@ -1,7 +1,6 @@
 # SPDX-License-Identifier: LGPL-2.1-or-later
 #
-# Copyright (C) 2023 KernelCI Authors.
-# Author: Sanskar Bhushan <sbdtu5498@gmail.com>
+# Copyright (C) 2023 Sanskar Bhushan <sbdtu5498@gmail.com>
 
 apiVersion: apps/v1
 kind: Deployment

--- a/kube/minkube/deployments/ssh-deployment.yaml
+++ b/kube/minkube/deployments/ssh-deployment.yaml
@@ -1,7 +1,6 @@
 # SPDX-License-Identifier: LGPL-2.1-or-later
 #
-# Copyright (C) 2023 KernelCI Authors.
-# Author: Sanskar Bhushan <sbdtu5498@gmail.com>
+# Copyright (C) 2023 Sanskar Bhushan <sbdtu5498@gmail.com>
 
 # This deployment may need some security checks.
 

--- a/kube/minkube/deployments/storage-deployment.yaml
+++ b/kube/minkube/deployments/storage-deployment.yaml
@@ -1,7 +1,6 @@
 # SPDX-License-Identifier: LGPL-2.1-or-later
 #
-# Copyright (C) 2023 KernelCI Authors.
-# Author: Sanskar Bhushan <sbdtu5498@gmail.com>
+# Copyright (C) 2023 Sanskar Bhushan <sbdtu5498@gmail.com>
 
 apiVersion: apps/v1
 kind: Deployment

--- a/kube/minkube/init/init-job.yaml
+++ b/kube/minkube/init/init-job.yaml
@@ -1,7 +1,6 @@
 # SPDX-License-Identifier: LGPL-2.1-or-later
 #
-# Copyright (C) 2023 KernelCI Authors.
-# Author: Sanskar Bhushan <sbdtu5498@gmail.com>
+# Copyright (C) 2023 Sanskar Bhushan <sbdtu5498@gmail.com>
 
 apiVersion: batch/v1
 kind: Job

--- a/kube/minkube/init/init-pod.yaml
+++ b/kube/minkube/init/init-pod.yaml
@@ -1,7 +1,6 @@
 # SPDX-License-Identifier: LGPL-2.1-or-later
 #
-# Copyright (C) 2023 KernelCI Authors.
-# Author: Sanskar Bhushan <sbdtu5498@gmail.com>
+# Copyright (C) 2023 Sanskar Bhushan <sbdtu5498@gmail.com>
 
 apiVersion: v1
 kind: Pod
@@ -16,9 +15,8 @@ spec:
     - name: data-volume
       mountPath: /data
     # resource limits needs to be discussed
-    resources: 
+    resources:
   volumes:
   - name: data-volume
     hostPath:
       path: /home/docker/kernelci-api
-

--- a/kube/minkube/pvc/db-pvc.yaml
+++ b/kube/minkube/pvc/db-pvc.yaml
@@ -1,7 +1,6 @@
 # SPDX-License-Identifier: LGPL-2.1-or-later
 #
-# Copyright (C) 2023 KernelCI Authors.
-# Author: Sanskar Bhushan <sbdtu5498@gmail.com>
+# Copyright (C) 2023 Sanskar Bhushan <sbdtu5498@gmail.com>
 
 apiVersion: v1
 kind: PersistentVolumeClaim

--- a/kube/minkube/services/api-service.yaml
+++ b/kube/minkube/services/api-service.yaml
@@ -1,7 +1,6 @@
 # SPDX-License-Identifier: LGPL-2.1-or-later
 #
-# Copyright (C) 2023 KernelCI Authors.
-# Author: Sanskar Bhushan <sbdtu5498@gmail.com>
+# Copyright (C) 2023 Sanskar Bhushan <sbdtu5498@gmail.com>
 
 apiVersion: v1
 kind: Service

--- a/kube/minkube/services/db-service.yaml
+++ b/kube/minkube/services/db-service.yaml
@@ -1,7 +1,6 @@
 # SPDX-License-Identifier: LGPL-2.1-or-later
 #
-# Copyright (C) 2023 KernelCI Authors.
-# Author: Sanskar Bhushan <sbdtu5498@gmail.com>
+# Copyright (C) 2023 Sanskar Bhushan <sbdtu5498@gmail.com>
 
 apiVersion: v1
 kind: Service

--- a/kube/minkube/services/redis-service.yaml
+++ b/kube/minkube/services/redis-service.yaml
@@ -1,7 +1,6 @@
 # SPDX-License-Identifier: LGPL-2.1-or-later
 #
-# Copyright (C) 2023 KernelCI Authors.
-# Author: Sanskar Bhushan <sbdtu5498@gmail.com>
+# Copyright (C) 2023 Sanskar Bhushan <sbdtu5498@gmail.com>
 
 apiVersion: v1
 kind: Service

--- a/kube/minkube/services/ssh-service.yaml
+++ b/kube/minkube/services/ssh-service.yaml
@@ -1,7 +1,6 @@
 # SPDX-License-Identifier: LGPL-2.1-or-later
 #
-# Copyright (C) 2023 KernelCI Authors.
-# Author: Sanskar Bhushan <sbdtu5498@gmail.com>
+# Copyright (C) 2023 Sanskar Bhushan <sbdtu5498@gmail.com>
 
 apiVersion: v1
 kind: Service

--- a/kube/minkube/services/storage-service.yaml
+++ b/kube/minkube/services/storage-service.yaml
@@ -1,7 +1,6 @@
 # SPDX-License-Identifier: LGPL-2.1-or-later
 #
-# Copyright (C) 2023 KernelCI Authors.
-# Author: Sanskar Bhushan <sbdtu5498@gmail.com>
+# Copyright (C) 2023 Sanskar Bhushan <sbdtu5498@gmail.com>
 
 apiVersion: v1
 kind: Service


### PR DESCRIPTION
Fix the copyright statements for Sanskar Bhushan to follow the convention of listing the copyright owners directly rather than referring to the "authors".  In many cases, the authors don't own the copyright if they're writing the code as part of their work with an employer.