### PR TITLE
doc: rename getting-started to local-instance

### DIFF
--- a/doc/local-instance.md
+++ b/doc/local-instance.md
@@ -1,8 +1,7 @@
 ---
-title: "Getting Started"
-date: 2023-07-24
-description: "Setting up a local instance"
-weight: 1
+title: "Local instance"
+date: 2023-09-01
+description: "Setting up a local KernelCI instance"
 ---
 
 This guide should provide all the basic information to set up a local


### PR DESCRIPTION
Rename the getting-started page to local-instance as it's more about setting up a local instance with docker-compose than starting to use the API from a user point of view.  Update the Hugo front-matter accordingly.