### PR TITLE
api.main: add node owner information to pubsub event

### DIFF
--- a/api/main.py
+++ b/api/main.py
@@ -393,6 +393,7 @@ def _get_node_event_data(operation, node):
         'state': node.state,
         'result': node.result,
         'revision': node.revision.dict(),
+        'owner': node.owner,
     }
 
 

--- a/tests/e2e_tests/test_pipeline.py
+++ b/tests/e2e_tests/test_pipeline.py
@@ -59,7 +59,8 @@ async def test_node_pipeline(test_async_client):
     await task_listen
     event_data = from_json(task_listen.result().json().get('data')).data
     assert event_data != 'BEEP'
-    keys = {'op', 'id', 'name', 'path', 'group', 'state', 'result', 'revision'}
+    keys = {'op', 'id', 'name', 'path', 'group', 'state', 'result', 'revision',
+            'owner'}
     assert keys == event_data.keys()
     assert event_data.get('op') == 'created'
     assert event_data.get('id') == response.json()['id']
@@ -81,6 +82,7 @@ async def test_node_pipeline(test_async_client):
     await task_listen
     event_data = from_json(task_listen.result().json().get('data')).data
     assert event_data != 'BEEP'
-    keys = {'op', 'id', 'name', 'path', 'group', 'state', 'result', 'revision'}
+    keys = {'op', 'id', 'name', 'path', 'group', 'state', 'result', 'revision',
+            'owner'}
     assert keys == event_data.keys()
     assert event_data.get('op') == 'updated'


### PR DESCRIPTION
Fixes https://github.com/kernelci/kernelci-api/issues/343

In order to enable filtering nodes based on owner, add node owner information to pubsub event data for `node` channel.