### PR TITLE
kube/aks/README.md: fix a minor typo

### DIFF
--- a/kube/aks/README.md
+++ b/kube/aks/README.md
@@ -251,7 +251,7 @@ cert-manager v1.8.0 has been deployed successfully!
 
 ## Set up the ingress
 
-Once the Kubernetes packages have been installed, the actuall ingress
+Once the Kubernetes packages have been installed, the actual ingress
 definition can be applied.  Still within the same container, run this command:
 
 ```


### PR DESCRIPTION
Fix a typo in `Set up the ingress` section.