### PR TITLE
api.operators: Add ne operator

### DIFF
--- a/api/db.py
+++ b/api/db.py
@@ -32,6 +32,7 @@ class Database:
         'lte': '$lte',
         'gt': '$gt',
         'gte': '$gte',
+        'ne': '$ne',
     }
 
     def __init__(self, service='mongodb://db:27017', db_name='kernelci'):

--- a/api/models.py
+++ b/api/models.py
@@ -278,9 +278,9 @@ class Node(DatabaseModel):
     def _translate_operators(cls, params):
         """Translate fields with an operator
 
-        The request query parameters can be provided with operators such `lt`,
-        `gt`, `lte`, and `gte` with `param__operator=value` format. This method
-        will generate translated parameters of the form:
+        The request query parameters can be provided with operators such `ne`,
+        `lt`, `gt`, `lte`, and `gte` with `param__operator=value` format.
+        This method will generate translated parameters of the form:
 
           `parameter, (operator, value)`
 


### PR DESCRIPTION
Not equal is one of necessary basic mongodb operators, which might come handy to exclude certain results.