### PR TITLE
api/main.py: Fix exception when node doesn't exist

### DIFF
--- a/api/main.py
+++ b/api/main.py
@@ -127,6 +127,11 @@ async def authorize_user(node_id: str, user: User = Depends(get_current_user)):
     # Only the user that created the node or any other user from the permitted
     # user groups will be allowed to update the node
     node_from_id = await db.find_by_id(Node, node_id)
+    if not node_from_id:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"Node not found with id: {node_id}"
+        )
     if not user.profile.username == node_from_id.owner:
         if not any(group.name in node_from_id.user_groups
                    for group in user.profile.groups):


### PR DESCRIPTION
If we submit over kci tool node with non-existing ID, then we will get exception:
```
[api-77fd989c9c-mdzjr]: INFO:     10.244.1.36:55856 - "PUT /latest/node/aaaabbcf8326c545a780f36c HTTP/1.1" 500 Internal Server Error
[api-77fd989c9c-mdzjr]: ERROR:    Exception in ASGI application
[api-77fd989c9c-mdzjr]: Traceback (most recent call last):
...
[api-77fd989c9c-mdzjr]:   File "/home/kernelci/.local/lib/python3.10/site-packages/fastapi/dependencies/utils.py", line 550, in solve_dependencies
[api-77fd989c9c-mdzjr]:     solved = await call(**sub_values)
[api-77fd989c9c-mdzjr]:   File "/home/kernelci/.local/lib/python3.10/site-packages/api/main.py", line 130, in authorize_user
[api-77fd989c9c-mdzjr]:     if not user.profile.username == node_from_id.owner:
[api-77fd989c9c-mdzjr]: AttributeError: 'NoneType' object has no attribute 'owner'
```