### PR TITLE
doc/early-access: clarify staging_config settings

### DIFF
--- a/doc/early-access.md
+++ b/doc/early-access.md
@@ -124,7 +124,9 @@ also use SSH or soon any S3-compatible storage.  There is a quota, currently
 so please don't rely on it for any persistent storage.
 
 The token from your confirmation email should also be stored in `kernelci.toml`
-in order to make use of it, for example:
+as `storage_cred` in order to make use of it, and it's convenient to also add a
+`storage_config` entry in the default section to avoid having to specify it all
+the time on the command line.  For example:
 
 ```toml
 [DEFAULT]


### PR DESCRIPTION
Clarify the documentation about setting up storage to also mention that it's convenient to add storage_config to the settings file to avoid having to keep passing --storage-config on the command line.