### PR TITLE
Fix some loose ends in the API overview page

### DIFF
--- a/doc/_index.md
+++ b/doc/_index.md
@@ -1,6 +1,6 @@
 ---
 title: "API & Pipeline"
-date: 2023-09-01
+date: 2023-09-27
 description: "KernelCI API and Pipeline"
 weight: 2
 ---
@@ -69,24 +69,37 @@ kernel build provided by KernelCI.
 
 ## Pipeline
 
-The Pipeline is all the client-side services which are running the actual
-workload (builds, tests etc.).  It's orchestrated based on events from the
-Pub/Sub interface and all the data is managed via the API.  Pipeline services
-are also responsible for uploading any artifacts to some independent storage
-services and provide public URLs to access them.
-
-A standard set of services is run directly by KernelCI alongside the API to
-automate the main part of the pipeline: detecting new kernel revision,
-scheduling builds and tests, sending email reports, detecting regressions.
+The Pipeline is made up of all the client-side services that run the actual
+workloads that produces data and artifacts.  It's orchestrated based on events
+from the Pub/Sub interface and all the data is managed via the API.  For
+example, the pipeline is responsible for detecting new kernel revision,
+scheduling builds and tests, sending email reports and detecting regressions.
 However, any other service which has an API token is in fact part of the
 extended pipeline too.
 
-Their respective GitHub repositories are
-[`kernelci-api`](https://github.com/kernelci/kernelci-api.git) and
-[`kernelci-pipeline`](https://github.com/kernelci/kernelci-pipeline.git).
+Pipeline services are also responsible for uploading various kinds of artifacts
+to some independent storage services and provide public URLs to access them.
+Artifacts typically include kernel source code tarballs, build artifacts, logs
+and test results in some raw format before they were submitted to the API.
 
-An instance has been set up on `staging.kernelci.org`.  The Docker logs are
-available in real-time via a [web
+## Instances
+
+### Staging
+
+An instance has been set up on `staging.kernelci.org` for testing all pending
+changes.  The Docker logs are available in real-time via a [web
 interface](https://staging.kernelci.org:9088/) for both the API and the
 pipeline.  It also provides some [interactive API
-documentation](https://staging.kernelci.org:9000/latest/docs).
+documentation](https://staging.kernelci.org:9000/latest/docs).  This instance
+is not stable, it's redeployed periodically with all open pull requests from
+GitHub merged together on a test integration branch.
+
+### Early Access
+
+In preparation for a full production roll-out, an [Early
+Access](/docs/api/early-access) instance has been deployed in the Cloud (AKS)
+on `kernelci-api.eastus.cloudapp.azure.com`.  This is stable enough to let
+users give it a try as some form of beta-testing and is used as a candidate
+solution for an initial production deployment in the coming months.  Like
+staging, it has an auto-generated [interactive API
+documentation](https://kernelci-api.eastus.cloudapp.azure.com/latest/docs).

--- a/doc/api-details.md
+++ b/doc/api-details.md
@@ -1,9 +1,12 @@
 ---
 title: "API details"
-date: 2022-11-25
+date: 2023-09-27
 description: "KernelCI API building blocks"
 weight: 3
 ---
+
+GitHub repository:
+[`kernelci-api`](https://github.com/kernelci/kernelci-api.git)
 
 This guide describes the KernelCI API components such as data models and the
 Pub/Sub interface in detail.  It also explains how to use the API directly for
@@ -153,7 +156,7 @@ $ curl 'http://localhost:8001/latest/nodes?name=checkout&revision.tree=mainline'
 [{"_id":"61b052199bca2a448fe49673","kind":"node","name":"checkout","revision":{"tree":"mainline","url":"https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git","branch":"master","commit":"2a987e65025e2b79c6d453b78cb5985ac6e5eb26","describe":"v5.16-rc4-31-g2a987e65025e"},"parent":null,"status":"pending","result":null, "created":"2022-02-01T11:23:03.157648", "updated":"2022-02-02T11:23:03.157648"}]
 ```
 
-Attributes along with comparison operators are also supported for the 
+Attributes along with comparison operators are also supported for the
 `/nodes` endpoint. The attribute name and operator should be separated by `__` i.e. `attribute__operator`. Supported operators are `lt`(less than), `gt`(greater than), `lte`(less than or equal to), and `gte`(greater than or equal to).
 
 ```

--- a/doc/pipeline-details.md
+++ b/doc/pipeline-details.md
@@ -1,11 +1,12 @@
 ---
 title: "Pipeline details"
-date: 2022-09-30
+date: 2023-09-27
 description: "KernelCI Pipeline design details"
 weight: 4
 ---
 
-## Pipeline detailed design
+GitHub repository:
+[`kernelci-pipeline`](https://github.com/kernelci/kernelci-pipeline.git)
 
 Below is the detailed pipeline flow diagram with associated node and pub/sub event:
 
@@ -29,7 +30,7 @@ flowchart
         runner_node --> runtime[Runtime Environment]
         runtime --> set_available[Update node<br />state=available, result=None, set holdoff]
         set_available --> run_job[Run build/test job]
-        run_job --> job_done{Job done?}       
+        run_job --> job_done{Job done?}
         job_done --> |Yes| pass_runner_node[Update node<br />state=done, result=pass/fail/skip]
         job_done --> |No| run_job
     end


### PR DESCRIPTION
Remove leftover bits at the bottom of the API overview page and adjust things accordingly.