### PR TITLE
PoC: `Redis List` for single consumer use case

### DIFF
--- a/docker/api/requirements.txt
+++ b/docker/api/requirements.txt
@@ -1,4 +1,3 @@
-aioredis[hiredis]==2.0.0
 cloudevents==1.9.0
 fastapi[all]==0.68.1
 fastapi-pagination==0.9.3
@@ -10,3 +9,4 @@ motor==2.5.1
 pymongo-migrate==0.11.0
 pyyaml==5.3.1
 fastapi-versioning==0.10.0
+redis==5.0.1


### PR DESCRIPTION
Integrated `redis` package.
Used `Redis List` data structure for single consumer use case instead of broadcasting messages with `Redis PubSub`.