### PR TITLE
tests/unit_tests: autouse `mock_init_sub_id` fixture

### DIFF
--- a/tests/unit_tests/conftest.py
+++ b/tests/unit_tests/conftest.py
@@ -159,7 +159,7 @@ def mock_get_current_admin_user(mocker):
     return async_mock
 
 
-@pytest.fixture
+@pytest.fixture(autouse=True)
 def mock_init_sub_id(mocker):
     """Mocks async call to PubSub method to initialize subscription id"""
     async_mock = AsyncMock()

--- a/tests/unit_tests/test_count_handler.py
+++ b/tests/unit_tests/test_count_handler.py
@@ -8,7 +8,7 @@
 """Unit test functions for KernelCI API count handler"""
 
 
-def test_count_nodes(mock_db_count, mock_init_sub_id, test_client):
+def test_count_nodes(mock_db_count, test_client):
     """
     Test Case : Test KernelCI API GET /count endpoint
     Expected Result :
@@ -22,8 +22,7 @@ def test_count_nodes(mock_db_count, mock_init_sub_id, test_client):
     assert response.json() >= 0
 
 
-def test_count_nodes_matching_attributes(mock_db_count, mock_init_sub_id,
-                                         test_client):
+def test_count_nodes_matching_attributes(mock_db_count, test_client):
     """
     Test Case : Test KernelCI API GET /count endpoint with attributes
     Expected Result :

--- a/tests/unit_tests/test_listen_handler.py
+++ b/tests/unit_tests/test_listen_handler.py
@@ -55,7 +55,7 @@ def test_listen_endpoint_not_found(mock_get_current_user,
 
 
 def test_listen_endpoint_without_token(mock_get_current_user,
-                                       mock_init_sub_id, test_client):
+                                       test_client):
     """
     Test Case : Test KernelCI API GET /listen endpoint for the
     negative path

--- a/tests/unit_tests/test_node_handler.py
+++ b/tests/unit_tests/test_node_handler.py
@@ -17,7 +17,7 @@ from api.models import Node, Revision
 from api.paginator_models import PageModel
 
 
-def test_create_node_endpoint(mock_get_current_user, mock_init_sub_id,
+def test_create_node_endpoint(mock_get_current_user,
                               mock_db_create, mock_publish_cloudevent,
                               test_client):
     """
@@ -93,7 +93,7 @@ def test_create_node_endpoint(mock_get_current_user, mock_init_sub_id,
 
 def test_get_nodes_by_attributes_endpoint(mock_get_current_user,
                                           mock_db_find_by_attributes,
-                                          mock_init_sub_id, test_client):
+                                          test_client):
     """
     Test Case : Test KernelCI API GET /nodes?attribute_name=attribute_value
     endpoint for the positive path
@@ -161,7 +161,6 @@ def test_get_nodes_by_attributes_endpoint(mock_get_current_user,
 def test_get_nodes_by_attributes_endpoint_node_not_found(
         mock_get_current_user,
         mock_db_find_by_attributes,
-        mock_init_sub_id,
         test_client):
     """
     Test Case : Test KernelCI API GET /nodes?attribute_name=attribute_value
@@ -192,7 +191,7 @@ def test_get_nodes_by_attributes_endpoint_node_not_found(
 
 
 def test_get_node_by_id_endpoint(mock_get_current_user, mock_db_find_by_id,
-                                 mock_init_sub_id, test_client):
+                                 test_client):
     """
     Test Case : Test KernelCI API GET /node/{node_id} endpoint
     for the positive path
@@ -247,7 +246,6 @@ def test_get_node_by_id_endpoint(mock_get_current_user, mock_db_find_by_id,
 
 def test_get_node_by_id_endpoint_empty_response(mock_get_current_user,
                                                 mock_db_find_by_id,
-                                                mock_init_sub_id,
                                                 test_client):
     """
     Test Case : Test KernelCI API GET /node/{node_id} endpoint
@@ -265,7 +263,7 @@ def test_get_node_by_id_endpoint_empty_response(mock_get_current_user,
 
 
 def test_get_all_nodes(mock_get_current_user, mock_db_find_by_attributes,
-                       mock_init_sub_id, test_client):
+                       test_client):
     """
     Test Case : Test KernelCI API GET /nodes endpoint for the
     positive path
@@ -347,7 +345,7 @@ def test_get_all_nodes(mock_get_current_user, mock_db_find_by_attributes,
 
 def test_get_all_nodes_empty_response(mock_get_current_user,
                                       mock_db_find_by_attributes,
-                                      mock_init_sub_id, test_client):
+                                      test_client):
     """
     Test Case : Test KernelCI API GET /nodes endpoint for the
     negative path

--- a/tests/unit_tests/test_root_handler.py
+++ b/tests/unit_tests/test_root_handler.py
@@ -8,7 +8,7 @@
 """Unit test function for KernelCI API root handler"""
 
 
-def test_root_endpoint(mock_init_sub_id, test_client):
+def test_root_endpoint(test_client):
     """
     Test Case : Test KernelCI API root endpoint
     Expected Result :

--- a/tests/unit_tests/test_subscribe_handler.py
+++ b/tests/unit_tests/test_subscribe_handler.py
@@ -11,7 +11,7 @@ from tests.unit_tests.conftest import BEARER_TOKEN
 from api.pubsub import Subscription
 
 
-def test_subscribe_endpoint(mock_get_current_user, mock_init_sub_id,
+def test_subscribe_endpoint(mock_get_current_user,
                             mock_subscribe, test_client):
     """
     Test Case : Test KernelCI API /subscribe endpoint

--- a/tests/unit_tests/test_token_handler.py
+++ b/tests/unit_tests/test_token_handler.py
@@ -14,7 +14,7 @@ from api.models import User, UserGroup, UserProfile
 
 
 def test_token_endpoint(mock_db_find_one_by_attributes,
-                        mock_init_sub_id, test_client):
+                        test_client):
     """
     Test Case : Test KernelCI API token endpoint
     Expected Result :
@@ -44,7 +44,6 @@ def test_token_endpoint(mock_db_find_one_by_attributes,
 
 
 def test_token_endpoint_incorrect_password(mock_db_find_one_by_attributes,
-                                           mock_init_sub_id,
                                            test_client):
     """
     Test Case : Test KernelCI API token endpoint for negative path
@@ -78,7 +77,6 @@ def test_token_endpoint_incorrect_password(mock_db_find_one_by_attributes,
 
 
 def test_token_endpoint_admin_user(mock_db_find_one_by_attributes,
-                                   mock_init_sub_id,
                                    test_client):
     """
     Test Case : Test KernelCI API token endpoint for admin user

--- a/tests/unit_tests/test_unsubscribe_handler.py
+++ b/tests/unit_tests/test_unsubscribe_handler.py
@@ -11,7 +11,7 @@ from tests.unit_tests.conftest import BEARER_TOKEN
 
 
 def test_unsubscribe_endpoint(mock_get_current_user,
-                              mock_init_sub_id, mock_unsubscribe, test_client):
+                              mock_unsubscribe, test_client):
     """
     Test Case : Test KernelCI API /unsubscribe endpoint positive path
     Expected Result :
@@ -27,7 +27,7 @@ def test_unsubscribe_endpoint(mock_get_current_user,
 
 
 def test_unsubscribe_endpoint_empty_response(mock_get_current_user,
-                                             mock_init_sub_id, test_client):
+                                             test_client):
     """
     Test Case : Test KernelCI API /unsubscribe endpoint negative path
     Expected Result :

--- a/tests/unit_tests/test_user_group_handler.py
+++ b/tests/unit_tests/test_user_group_handler.py
@@ -17,7 +17,7 @@ from api.models import UserGroup
 from api.paginator_models import PageModel
 
 
-def test_create_user_group(mock_init_sub_id, mock_get_current_admin_user,
+def test_create_user_group(mock_get_current_admin_user,
                            mock_db_create, mock_publish_cloudevent,
                            test_client):
     """
@@ -44,8 +44,7 @@ def test_create_user_group(mock_init_sub_id, mock_get_current_admin_user,
     assert ('id', 'name') == tuple(response.json().keys())
 
 
-def test_create_group_endpoint_negative(mock_init_sub_id,
-                                        mock_get_current_user,
+def test_create_group_endpoint_negative(mock_get_current_user,
                                         mock_publish_cloudevent,
                                         test_client):
     """
@@ -70,7 +69,7 @@ def test_create_group_endpoint_negative(mock_init_sub_id,
     assert response.json() == {'detail': 'Access denied'}
 
 
-def test_get_groups(mock_init_sub_id, mock_db_find_by_attributes,
+def test_get_groups(mock_db_find_by_attributes,
                     test_client):
     """
     Test Case : Test KernelCI API GET /groups endpoint
@@ -97,7 +96,7 @@ def test_get_groups(mock_init_sub_id, mock_db_find_by_attributes,
             'offset') == tuple(response.json().keys())
 
 
-def test_get_group_by_id(mock_init_sub_id, mock_db_find_by_id,
+def test_get_group_by_id(mock_db_find_by_id,
                          test_client):
     """
     Test Case : Test KernelCI API GET /group/{group_id} endpoint

--- a/tests/unit_tests/test_user_handler.py
+++ b/tests/unit_tests/test_user_handler.py
@@ -16,7 +16,7 @@ from tests.unit_tests.conftest import (
 from api.models import User, UserGroup, UserProfile
 
 
-def test_create_regular_user(mock_init_sub_id, mock_get_current_admin_user,
+def test_create_regular_user(mock_get_current_admin_user,
                              mock_db_create, mock_publish_cloudevent,
                              test_client):
     """
@@ -48,7 +48,6 @@ HR5UHMdMFQeOe1eD4oXaP08oW7ogYqyiNziZYNdUHs8i", email='test@kernelci.org')
 
 
 def test_create_admin_user(  # pylint: disable=too-many-arguments
-                           mock_init_sub_id,
                            mock_get_current_admin_user,
                            mock_db_create, mock_publish_cloudevent,
                            test_client, mock_db_find_one):
@@ -85,7 +84,7 @@ W7ogYqyiNziZYNdUHs8i",
             'groups', 'email') == tuple(response.json()['profile'].keys())
 
 
-def test_create_user_endpoint_negative(mock_init_sub_id, mock_get_current_user,
+def test_create_user_endpoint_negative(mock_get_current_user,
                                        mock_publish_cloudevent, test_client):
     """
     Test Case : Test KernelCI API /user endpoint when requested
@@ -110,7 +109,6 @@ def test_create_user_endpoint_negative(mock_init_sub_id, mock_get_current_user,
 
 
 def test_create_user_with_group(  # pylint: disable=too-many-arguments
-                           mock_init_sub_id,
                            mock_get_current_admin_user,
                            mock_db_create, mock_publish_cloudevent,
                            test_client, mock_db_find_one):
@@ -148,7 +146,7 @@ ogYqyiNziZYNdUHs8i",
 
 
 def test_get_user_by_id_endpoint(mock_get_current_admin_user, mock_db_find_by_id,
-                                 mock_init_sub_id, test_client):
+                                 test_client):
     """
     Test Case : Test KernelCI API GET /user/{user_id} endpoint with admin
     token

--- a/tests/unit_tests/test_whoami_handler.py
+++ b/tests/unit_tests/test_whoami_handler.py
@@ -13,7 +13,7 @@
 from tests.unit_tests.conftest import BEARER_TOKEN
 
 
-def test_whoami_endpoint(mock_get_current_user, mock_init_sub_id, test_client):
+def test_whoami_endpoint(mock_get_current_user, test_client):
     """
     Test Case : Test KernelCI API /whoami endpoint
     Expected Result :


### PR DESCRIPTION
Pytest fixture `mock_init_sub_id` is used to mock Pub/Sub initializer function call. As the function is called on app startup, all the unit tests call it by default upon test execution. Instead of explicitly calling the fixture from all the tests, mark the fixture with `autouse=True`. This will make all tests automatically request it.