### PR TITLE
README.md: fix `API Testing` section for unit tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ export $(cat .env)
 
 Run the below command from kernelci-api directory:
 ```
-pytest -v test/
+pytest -v tests/unit_tests/
 ```
 This will start running unit test cases from kernelci-api/test directory and display results.
 


### PR DESCRIPTION
Test directory structure has been changed
to have two separate directories for unit tests and e2e tests named `unit_tests` and `e2e_tests` respectively. Fix command to run unit tests in the README.md file by renaming test directory.