### PR TITLE
tests/unit_tests: remove request to init Pub/Sub mock

### DIFF
--- a/tests/unit_tests/test_listen_handler.py
+++ b/tests/unit_tests/test_listen_handler.py
@@ -14,7 +14,6 @@ from tests.unit_tests.conftest import BEARER_TOKEN
 
 
 def test_listen_endpoint(mock_get_current_user,
-                         mock_init_sub_id,
                          mock_listen, test_client):
     """
     Test Case : Test KernelCI API GET /listen endpoint for the
@@ -35,7 +34,7 @@ def test_listen_endpoint(mock_get_current_user,
 
 
 def test_listen_endpoint_not_found(mock_get_current_user,
-                                   mock_init_sub_id, test_client):
+                                   test_client):
     """
     Test Case : Test KernelCI API GET /listen endpoint for the
     negative path


### PR DESCRIPTION
Eliminate request to mock function for Pub/Sub initialization from `/listen` handler tests.

Fixes of what I missed in https://github.com/kernelci/kernelci-api/pull/382