### PR TITLE
Add `api.config` module for `Settings`

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -57,6 +57,10 @@ jobs:
       - name: Export environment variables
         run: |
           echo "SECRET_KEY=$(openssl rand -hex 32)" >> $GITHUB_ENV
+          echo "SMTP_HOST=smtp.gmail.com" >> $GITHUB_ENV
+          echo "SMTP_PORT=465" >> $GITHUB_ENV
+          echo "EMAIL_SENDER=test@kernelci.org" >> $GITHUB_ENV
+          echo "EMAIL_PASSWORD=random" >> $GITHUB_ENV
 
       - name: Run pytest
         run: |

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -50,6 +50,8 @@ jobs:
           pylint api.main
           pylint api.models
           pylint api.pubsub
+          pylint api.user_manager
+          pylint api.user_models
           pylint tests/unit_tests
 
       - name: Export environment variables

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -30,6 +30,10 @@ jobs:
       - name: Export environment variables
         run: |
           echo "SECRET_KEY=$(openssl rand -hex 32)" > .env
+          echo "SMTP_HOST=smtp.gmail.com" >> .env
+          echo "SMTP_PORT=465" >> .env
+          echo "EMAIL_SENDER=test@kernelci.org" >> .env
+          echo "EMAIL_PASSWORD=random" >> .env
 
       - name: Build docker images
         run: docker-compose -f test-docker-compose.yaml build

--- a/api/admin.py
+++ b/api/admin.py
@@ -17,7 +17,8 @@ import getpass
 
 from .auth import Authentication
 from .db import Database
-from .models import User, UserGroup, UserProfile
+from .models import UserGroup
+from .user_models import User
 
 
 async def setup_admin_group(db, admin_group):
@@ -42,19 +43,18 @@ async def setup_admin_user(db, username, email, admin_group):
         return None
     hashed_password = Authentication.get_password_hash(password)
     print(f"Creating {username} user...")
-    profile = UserProfile(
+    return await db.create(User(
         username=username,
         hashed_password=hashed_password,
         email=email,
-        groups=[admin_group]
-    )
-    return await db.create(User(
-        profile=profile
+        groups=[admin_group],
+        is_superuser=1
     ))
 
 
 async def main(args):
     db = Database(args.mongo, args.database)
+    await db.initialize_beanie()
     group = await setup_admin_group(db, args.admin_group)
     user = await setup_admin_user(db, args.username, args.email, group)
     return True

--- a/api/auth.py
+++ b/api/auth.py
@@ -7,20 +7,12 @@
 """User authentication utilities"""
 
 from passlib.context import CryptContext
-from pydantic import BaseSettings
 from fastapi_users.authentication import (
     AuthenticationBackend,
     BearerTransport,
     JWTStrategy,
 )
-
-
-class Settings(BaseSettings):
-    """Authentication settings"""
-    secret_key: str
-    algorithm: str = "HS256"
-    # Set to None so tokens don't expire
-    access_token_expire_seconds: int = None
+from .config import AuthSettings
 
 
 class Authentication:
@@ -29,7 +21,7 @@ class Authentication:
     CRYPT_CTX = CryptContext(schemes=["bcrypt"], deprecated="auto")
 
     def __init__(self, token_url: str):
-        self._settings = Settings()
+        self._settings = AuthSettings()
         self._token_url = token_url
 
     @classmethod

--- a/api/auth.py
+++ b/api/auth.py
@@ -6,28 +6,13 @@
 
 """User authentication utilities"""
 
-from datetime import datetime, timedelta
-from fastapi.security import OAuth2PasswordBearer
-from jose import JWTError, jwt
 from passlib.context import CryptContext
-from pydantic import BaseModel, BaseSettings, Field
+from pydantic import BaseSettings
 from fastapi_users.authentication import (
     AuthenticationBackend,
     BearerTransport,
     JWTStrategy,
 )
-from .db import Database
-from .models import User
-
-
-class Token(BaseModel):
-    """Authentication token model"""
-    access_token: str = Field(
-        description='Authentication access token'
-    )
-    token_type: str = Field(
-        description='Access token type e.g. Bearer'
-    )
 
 
 class Settings(BaseSettings):
@@ -35,108 +20,29 @@ class Settings(BaseSettings):
     secret_key: str
     algorithm: str = "HS256"
     # Set to None so tokens don't expire
-    access_token_expire_minutes: float = None
+    access_token_expire_seconds: int = None
 
 
 class Authentication:
-    """Authentication utility class
-
-    This class accepts a single argument `database` in its constructor, which
-    should be a db.Database object.
-    """
+    """Authentication utility class"""
 
     CRYPT_CTX = CryptContext(schemes=["bcrypt"], deprecated="auto")
 
-    def __init__(self, database: Database, token_url: str, user_scopes: dict):
-        self._db = database
+    def __init__(self, token_url: str):
         self._settings = Settings()
-        self._user_scopes = user_scopes
-        self._oauth2_scheme = OAuth2PasswordBearer(
-                tokenUrl=token_url,
-                scopes=self._user_scopes
-        )
-
-    @property
-    def oauth2_scheme(self):
-        """Get authentication scheme"""
-        return self._oauth2_scheme
+        self._token_url = token_url
 
     @classmethod
     def get_password_hash(cls, password):
         """Get a password hash for a given clear text password string"""
         return cls.CRYPT_CTX.hash(password)
 
-    @classmethod
-    def verify_password(cls, password_hash, user):
-        """Verify that the password hash matches the user's password"""
-        return cls.CRYPT_CTX.verify(password_hash, user.hashed_password)
-
-    async def authenticate_user(self, username: str, password: str):
-        """Authenticate a username / password pair
-
-        Look up a `User` in the database with the provided `username`
-        and check whether the provided clear text `password` matches the hash
-        associated with it.
-        """
-        user = await self._db.find_one_by_attributes(
-            User, {'profile.username': username})
-        if not user:
-            return False
-        if not self.verify_password(password, user.profile):
-            return False
-        return user.profile
-
-    def create_access_token(self, data: dict):
-        """Create a JWT access token using the provided arbitrary `data`"""
-        to_encode = data.copy()
-        if self._settings.access_token_expire_minutes:
-            expires_delta = timedelta(
-                    minutes=self._settings.access_token_expire_minutes
-                    )
-            expire = datetime.utcnow() + expires_delta
-            to_encode.update({"exp": expire})
-        encoded_jwt = jwt.encode(
-            to_encode,
-            self._settings.secret_key, algorithm=self._settings.algorithm
-            )
-        return encoded_jwt
-
-    async def get_current_user(self, token, security_scopes):
-        """Decode the given JWT `token` and look up a matching `User`"""
-        try:
-            payload = jwt.decode(
-                token,
-                self._settings.secret_key,
-                algorithms=[self._settings.algorithm]
-            )
-            username: str = payload.get("sub")
-            token_scopes = payload.get("scopes", [])
-            if username is None:
-                return None, "Could not validate credentials"
-
-            for scope in security_scopes:
-                if scope not in token_scopes:
-                    return None, "Access denied"
-
-        except JWTError as error:
-            return None, str(error)
-
-        user = await self._db.find_one_by_attributes(
-            User, {'profile.username': username})
-        return user, None
-
-    async def validate_scopes(self, requested_scopes):
-        """Check if requested scopes are valid user scopes"""
-        for scope in requested_scopes:
-            if scope not in self._user_scopes:
-                return False, scope
-        return True, None
-
     def get_jwt_strategy(self) -> JWTStrategy:
         """Get JWT strategy for authentication backend"""
         return JWTStrategy(
             secret=self._settings.secret_key,
-            lifetime_seconds=self._settings.access_token_expire_minutes
+            algorithm=self._settings.algorithm,
+            lifetime_seconds=self._settings.access_token_expire_seconds
         )
 
     def get_user_authentication_backend(self):
@@ -148,7 +54,7 @@ class Authentication:
         Strategy is a method to generate and secure tokens. It can be JWT,
         database or Redis.
         """
-        bearer_transport = BearerTransport(tokenUrl="user/login")
+        bearer_transport = BearerTransport(tokenUrl=self._token_url)
         return AuthenticationBackend(
             name="jwt",
             transport=bearer_transport,

--- a/api/config.py
+++ b/api/config.py
@@ -1,0 +1,32 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+#
+# Copyright (C) 2023 Collabora Limited
+# Author: Jeny Sadadia <jeny.sadadia@collabora.com>
+
+"""Module settings"""
+
+from pydantic import BaseSettings, EmailStr
+
+
+class AuthSettings(BaseSettings):
+    """Authentication settings"""
+    secret_key: str
+    algorithm: str = "HS256"
+    # Set to None so tokens don't expire
+    access_token_expire_seconds: float = None
+
+
+class PubSubSettings(BaseSettings):
+    """Pub/Sub settings loaded from the environment"""
+    cloud_events_source: str = "https://api.kernelci.org/"
+    redis_host: str = "redis"
+    redis_db_number: int = 1
+    keep_alive_period: int = 45
+
+
+class EmailSettings(BaseSettings):
+    """Email settings"""
+    smtp_host: str
+    smtp_port: int
+    email_sender: EmailStr
+    email_password: str

--- a/api/db.py
+++ b/api/db.py
@@ -7,9 +7,11 @@
 """Database abstraction"""
 
 from bson import ObjectId
+from beanie import init_beanie
 from fastapi_pagination.ext.motor import paginate
 from motor import motor_asyncio
-from .models import Hierarchy, Node, User, Regression, UserGroup
+from .models import Hierarchy, Node, Regression, UserGroup
+from .user_models import User
 
 
 class Database:
@@ -38,6 +40,15 @@ class Database:
     def __init__(self, service='mongodb://db:27017', db_name='kernelci'):
         self._motor = motor_asyncio.AsyncIOMotorClient(service)
         self._db = self._motor[db_name]
+
+    async def initialize_beanie(self):
+        """Initialize Beanie ODM to use `fastapi-users` tools for MongoDB"""
+        await init_beanie(
+            database=self._db,
+            document_models=[
+                User,
+            ],
+        )
 
     def _get_collection(self, model):
         col = self.COLLECTIONS[model]

--- a/api/email_sender.py
+++ b/api/email_sender.py
@@ -11,21 +11,13 @@ from email.mime.multipart import MIMEMultipart
 import email
 import email.mime.text
 import smtplib
-from pydantic import BaseSettings, EmailStr
-
-
-class Settings(BaseSettings):
-    """Email settings"""
-    smtp_host: str
-    smtp_port: int
-    email_sender: EmailStr
-    email_password: str
+from .config import EmailSettings
 
 
 class EmailSender:
     """Class to send email report using SMTP"""
     def __init__(self):
-        self._settings = Settings()
+        self._settings = EmailSettings()
 
     def _smtp_connect(self):
         """Method to create a connection with SMTP server"""

--- a/api/email_sender.py
+++ b/api/email_sender.py
@@ -1,0 +1,69 @@
+#!/usr/bin/env python3
+#
+# SPDX-License-Identifier: LGPL-2.1-or-later
+#
+# Copyright (C) 2023 Jeny Sadadia
+# Author: Jeny Sadadia <jeny.sadadia@collabora.com>
+
+"""SMTP Email Sender module"""
+
+from email.mime.multipart import MIMEMultipart
+import email
+import email.mime.text
+import smtplib
+from pydantic import BaseSettings, EmailStr
+
+
+class Settings(BaseSettings):
+    """Email settings"""
+    smtp_host: str
+    smtp_port: int
+    email_sender: EmailStr
+    email_password: str
+
+
+class EmailSender:
+    """Class to send email report using SMTP"""
+    def __init__(self):
+        self._settings = Settings()
+
+    def _smtp_connect(self):
+        """Method to create a connection with SMTP server"""
+        if self._settings.smtp_port == 465:
+            smtp = smtplib.SMTP_SSL(self._settings.smtp_host,
+                                    self._settings.smtp_port)
+        else:
+            smtp = smtplib.SMTP(self._settings.smtp_host,
+                                self._settings.smtp_port)
+            smtp.starttls()
+        smtp.login(self._settings.email_sender,
+                   self._settings.email_password)
+        return smtp
+
+    def _create_email(self, email_subject, email_content, email_recipient):
+        """Method to create an email message from email subject, contect,
+        sender, and receiver"""
+        email_msg = MIMEMultipart()
+        email_text = email.mime.text.MIMEText(email_content, "plain", "utf-8")
+        email_text.replace_header('Content-Transfer-Encoding', 'quopri')
+        email_text.set_payload(email_content, 'utf-8')
+        email_msg.attach(email_text)
+        email_msg['To'] = email_recipient
+        email_msg['From'] = self._settings.email_sender
+        email_msg['Subject'] = email_subject
+        return email_msg
+
+    def _send_email(self, email_msg):
+        """Method to send an email message using SMTP"""
+        smtp = self._smtp_connect()
+        if smtp:
+            smtp.send_message(email_msg)
+            smtp.quit()
+
+    def create_and_send_email(self, email_subject, email_content,
+                              email_recipient):
+        """Method to create and send email"""
+        email_msg = self._create_email(
+            email_subject, email_content, email_recipient
+        )
+        self._send_email(email_msg)

--- a/api/main.py
+++ b/api/main.py
@@ -220,16 +220,6 @@ async def get_users(request: Request):
     return paginated_resp
 
 
-@app.get('/user/{user_id}', response_model=User,
-         response_model_by_alias=False,
-         response_model_exclude={"profile": {"hashed_password"}})
-async def get_user_by_id(
-        user_id: str,
-        current_user: User = Security(get_user, scopes=["admin"])):
-    """Get user matching provided user id"""
-    return await db.find_by_id(User, user_id)
-
-
 @app.put('/user/profile/{username}', response_model=User,
          response_model_include={"profile"},
          response_model_by_alias=False)

--- a/api/main.py
+++ b/api/main.py
@@ -47,6 +47,9 @@ from .pubsub import PubSub, Subscription
 from .user_manager import get_user_manager
 from .user_models import (
     User,
+    UserRead,
+    UserCreate,
+    UserUpdate,
 )
 
 # List of all the supported API versions.  This is a placeholder until the API
@@ -697,6 +700,38 @@ async def put_regression(regression_id: str, regression: Regression,
     await pubsub.publish_cloudevent('regression', {'op': operation,
                                                    'id': str(obj.id)})
     return obj
+
+
+# -----------------------------------------------------------------------------
+# Users
+
+app.include_router(
+    fastapi_users_instance.get_auth_router(auth_backend,
+                                           requires_verification=True),
+    prefix="/user",
+    tags=["user"]
+)
+app.include_router(
+    fastapi_users_instance.get_register_router(UserRead, UserCreate),
+    prefix="/user",
+    tags=["user"],
+)
+app.include_router(
+    fastapi_users_instance.get_reset_password_router(),
+    prefix="/user",
+    tags=["user"],
+)
+app.include_router(
+    fastapi_users_instance.get_verify_router(UserRead),
+    prefix="/user",
+    tags=["user"],
+)
+app.include_router(
+    fastapi_users_instance.get_users_router(UserRead, UserUpdate,
+                                            requires_verification=True),
+    prefix="/user",
+    tags=["user"],
+)
 
 
 app = VersionedFastAPI(

--- a/api/main.py
+++ b/api/main.py
@@ -54,9 +54,7 @@ API_VERSIONS = ['v0']
 
 app = FastAPI()
 db = Database(service=(os.getenv('MONGO_SERVICE') or 'mongodb://db:27017'))
-auth = Authentication(db, token_url='token',
-                      user_scopes={"admin": "Superusers",
-                                   "users": "Regular users"})
+auth = Authentication(token_url="user/login")
 pubsub = None  # pylint: disable=invalid-name
 
 auth_backend = auth.get_user_authentication_backend()

--- a/api/main.py
+++ b/api/main.py
@@ -624,7 +624,7 @@ async def put_regression(regression_id: str, regression: Regression,
     return obj
 
 
-app = VersionedFastAPI(
+versioned_app = VersionedFastAPI(
         app,
         version_format='{major}',
         prefix_format='/v{major}',
@@ -642,7 +642,7 @@ app = VersionedFastAPI(
 The issue has already been reported here:
 https://github.com/DeanWay/fastapi-versioning/issues/30
 """
-for sub_app in app.routes:
+for sub_app in versioned_app.routes:
     if hasattr(sub_app.app, "add_exception_handler"):
         sub_app.app.add_exception_handler(
             ValueError, value_error_exception_handler

--- a/api/main.py
+++ b/api/main.py
@@ -114,6 +114,8 @@ async def invalid_id_exception_handler(
     )
 
 current_active_user = fastapi_users_instance.current_user(active=True)
+current_active_superuser = fastapi_users_instance.current_user(active=True,
+                                                               superuser=True)
 
 
 async def get_current_user(
@@ -277,7 +279,7 @@ async def put_user(
 @app.post('/group', response_model=UserGroup, response_model_by_alias=False)
 async def post_user_group(
         group: UserGroup,
-        current_user: User = Security(get_user, scopes=["admin"])):
+        current_user: User = Depends(current_active_superuser)):
     """Create new user group"""
     try:
         obj = await db.create(group)
@@ -657,7 +659,8 @@ register_router = fastapi_users_instance.get_register_router(
 
 @app.post("/user/register", response_model=UserRead, tags=["user"],
           response_model_by_alias=False)
-async def register(request: Request, user: UserCreate):
+async def register(request: Request, user: UserCreate,
+                   current_user: str = Depends(current_active_superuser)):
     """User registration route
 
     Custom user registration router to ensure unique username.

--- a/api/main.py
+++ b/api/main.py
@@ -30,6 +30,7 @@ from fastapi_versioning import VersionedFastAPI
 from bson import ObjectId, errors
 from pymongo.errors import DuplicateKeyError
 from fastapi_users import FastAPIUsers
+from fastapi_users.db import BeanieUserDatabase
 from beanie import PydanticObjectId
 from .auth import Authentication, Token
 from .db import Database
@@ -51,6 +52,8 @@ from .user_models import (
     UserCreate,
     UserUpdate,
 )
+from .user_manager import UserManager
+
 
 # List of all the supported API versions.  This is a placeholder until the API
 # actually supports multiple versions with different sets of endpoints and
@@ -166,42 +169,6 @@ async def authorize_user(node_id: str, user: User = Depends(get_current_user)):
                 detail="Unauthorized to complete the operation"
             )
     return user
-
-
-@app.post('/user/{username}', response_model=User,
-          response_model_by_alias=False)
-async def post_user(
-        username: str, password: Password, email: str,
-        groups: List[str] = Query([]),
-        current_user: User = Security(get_user, scopes=["admin"])):
-    """Create new user"""
-    try:
-        hashed_password = auth.get_password_hash(
-                                password.password.get_secret_value())
-        group_obj = []
-        if groups:
-            for group_name in groups:
-                group = await db.find_one(UserGroup, name=group_name)
-                if not group:
-                    raise HTTPException(
-                        status_code=status.HTTP_400_BAD_REQUEST,
-                        detail=f"User group does not exist with name: \
-{group_name}")
-                group_obj.append(group)
-        profile = UserProfile(
-                    username=username,
-                    hashed_password=hashed_password,
-                    groups=group_obj,
-                    email=email)
-        obj = await db.create(User(profile=profile))
-    except DuplicateKeyError as error:
-        raise HTTPException(
-            status_code=status.HTTP_400_BAD_REQUEST,
-            detail=f"{username} is already taken. Try with different username."
-        ) from error
-    await pubsub.publish_cloudevent('user', {'op': 'created',
-                                             'id': str(obj.id)})
-    return obj
 
 
 @app.get('/users', response_model=PageModel,
@@ -679,11 +646,49 @@ app.include_router(
     prefix="/user",
     tags=["user"]
 )
-app.include_router(
-    fastapi_users_instance.get_register_router(UserRead, UserCreate),
-    prefix="/user",
-    tags=["user"],
-)
+
+register_router = fastapi_users_instance.get_register_router(
+    UserRead, UserCreate)
+
+
+@app.post("/user/register", response_model=UserRead, tags=["user"],
+          response_model_by_alias=False)
+async def register(request: Request, user: UserCreate):
+    """User registration route
+
+    Custom user registration router to ensure unique username.
+    `user` from request has a list of user group name strings.
+    This handler will convert them to `UserGroup` objects and
+    insert user object to database.
+    """
+    existing_user = await db.find_one(User, username=user.username)
+    if existing_user:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Username already exists",
+        )
+    groups = []
+    if user.groups:
+        for group_name in user.groups:
+            group = await db.find_one(UserGroup, name=group_name)
+            if not group:
+                raise HTTPException(
+                    status_code=status.HTTP_400_BAD_REQUEST,
+                    detail=f"User group does not exist with name: \
+    {group_name}")
+            groups.append(group)
+    user.groups = groups
+    created_user = await register_router.routes[0].endpoint(
+        request, user, UserManager(BeanieUserDatabase(User)))
+    # Update user to be an admin user explicitly if requested as
+    # `fastapi-users` register route does not allow it
+    if user.is_superuser:
+        user_from_id = await db.find_by_id(User, created_user.id)
+        user_from_id.is_superuser = True
+        created_user = await db.update(user_from_id)
+    return created_user
+
+
 app.include_router(
     fastapi_users_instance.get_reset_password_router(),
     prefix="/user",

--- a/api/main.py
+++ b/api/main.py
@@ -29,13 +29,14 @@ from fastapi_pagination import add_pagination
 from fastapi_versioning import VersionedFastAPI
 from bson import ObjectId, errors
 from pymongo.errors import DuplicateKeyError
+from fastapi_users import FastAPIUsers
+from beanie import PydanticObjectId
 from .auth import Authentication, Token
 from .db import Database
 from .models import (
     Node,
     Hierarchy,
     Regression,
-    User,
     UserGroup,
     UserProfile,
     Password,
@@ -43,6 +44,10 @@ from .models import (
 )
 from .paginator_models import PageModel
 from .pubsub import PubSub, Subscription
+from .user_manager import get_user_manager
+from .user_models import (
+    User,
+)
 
 # List of all the supported API versions.  This is a placeholder until the API
 # actually supports multiple versions with different sets of endpoints and
@@ -55,6 +60,12 @@ auth = Authentication(db, token_url='token',
                       user_scopes={"admin": "Superusers",
                                    "users": "Regular users"})
 pubsub = None  # pylint: disable=invalid-name
+
+auth_backend = auth.get_user_authentication_backend()
+fastapi_users_instance = FastAPIUsers[User, PydanticObjectId](
+    get_user_manager,
+    [auth_backend],
+)
 
 
 @app.on_event('startup')

--- a/api/main.py
+++ b/api/main.py
@@ -70,6 +70,12 @@ async def create_indexes():
     await db.create_indexes()
 
 
+@app.on_event('startup')
+async def initialize_beanie():
+    """Startup event handler to initialize Beanie"""
+    await db.initialize_beanie()
+
+
 @app.exception_handler(ValueError)
 async def value_error_exception_handler(request: Request, exc: ValueError):
     """Global exception handler for 'ValueError'"""
@@ -691,6 +697,7 @@ app = VersionedFastAPI(
         on_startup=[
             pubsub_startup,
             create_indexes,
+            initialize_beanie,
         ]
     )
 

--- a/api/main.py
+++ b/api/main.py
@@ -204,32 +204,10 @@ async def post_user(
     return obj
 
 
-@app.get('/users/profile', response_model=PageModel,
-         response_model_include={"items": {"__all__": {"profile": {
-                                    "username", "groups", "email"}}},
-                                 "total": {"__all__"},
-                                 "limit": {"__all__"},
-                                 "offset": {"__all__"},
-                                 })
-async def get_users_profile(request: Request):
-    """Get profile of all the users if no request parameters have passed.
-       Get the matching user profile otherwise."""
-    query_params = dict(request.query_params)
-    # Drop pagination parameters from query as they're already in arguments
-    for pg_key in ['limit', 'offset']:
-        query_params.pop(pg_key, None)
-    paginated_resp = await db.find_by_attributes(User, query_params)
-    paginated_resp.items = serialize_paginated_data(
-        User, paginated_resp.items)
-    return paginated_resp
-
-
 @app.get('/users', response_model=PageModel,
-         response_model_exclude={"items": {"__all__": {"profile": {
-                                    "hashed_password"}}}})
-async def get_users(
-        request: Request,
-        current_user: User = Security(get_user, scopes=["admin"])):
+         response_model_exclude={"items": {"__all__": {
+                                    "hashed_password"}}})
+async def get_users(request: Request):
     """Get all the users if no request parameters have passed.
        Get the matching users otherwise."""
     query_params = dict(request.query_params)

--- a/api/models.py
+++ b/api/models.py
@@ -18,8 +18,6 @@ from pydantic import (
     AnyHttpUrl,
     AnyUrl,
     BaseModel,
-    conlist,
-    EmailStr,
     Field,
     FileUrl,
     SecretStr,
@@ -116,36 +114,6 @@ class UserGroup(DatabaseModel):
     def create_indexes(cls, collection):
         """Create an index to bind unique constraint to group name"""
         collection.create_index("name", unique=True)
-
-
-class UserProfile(BaseModel):
-    """API user profile model"""
-    username: str
-    hashed_password: str = Field(description="Hash of the plaintext password")
-    groups: conlist(UserGroup, unique_items=True) = Field(
-        default=[],
-        description="A list of groups that user belongs to"
-    )
-    email: EmailStr = Field(
-        description="User email address"
-    )
-
-
-class User(DatabaseModel):
-    """API user model
-    The model will be accessible by admin users only"""
-    active: bool = Field(
-        default=True,
-        description="To check if user is active or not"
-    )
-    profile: UserProfile = Field(
-        description="User profile details accessible by all users"
-    )
-
-    @classmethod
-    def create_indexes(cls, collection):
-        """Create an index to bind unique constraint to username"""
-        collection.create_index("profile.username", unique=True)
 
 
 class KernelVersion(BaseModel):

--- a/api/pubsub.py
+++ b/api/pubsub.py
@@ -9,15 +9,8 @@ import asyncio
 
 import aioredis
 from cloudevents.http import CloudEvent, to_json
-from pydantic import BaseModel, BaseSettings, Field
-
-
-class Settings(BaseSettings):
-    """Pub/Sub settings loaded from the environment"""
-    cloud_events_source: str = "https://api.kernelci.org/"
-    redis_host: str = "redis"
-    redis_db_number: int = 1
-    keep_alive_period: int = 45
+from pydantic import BaseModel, Field
+from .config import PubSubSettings
 
 
 class Subscription(BaseModel):
@@ -49,7 +42,8 @@ class PubSub:
         return pubsub
 
     def __init__(self, host=None, db_number=None):
-        self._settings = Settings()
+        # self._settings = Settings()
+        self._settings = PubSubSettings()
         if host is None:
             host = self._settings.redis_host
         if db_number is None:

--- a/api/user_manager.py
+++ b/api/user_manager.py
@@ -18,13 +18,13 @@ from fastapi_users.password import PasswordHelperProtocol
 from beanie import PydanticObjectId
 import jinja2
 from .user_models import User
-from .auth import Settings
+from .config import AuthSettings
 from .email_sender import EmailSender
 
 
 class UserManager(ObjectIDIDMixin, BaseUserManager[User, PydanticObjectId]):
     """User management logic"""
-    settings = Settings()
+    settings = AuthSettings()
     reset_password_token_secret = settings.secret_key
     verification_token_secret = settings.secret_key
 

--- a/api/user_manager.py
+++ b/api/user_manager.py
@@ -6,7 +6,9 @@
 """User Manager"""
 
 from typing import Optional, Any, Dict
-from fastapi_users import BaseUserManager
+from fastapi import Depends, Request
+from fastapi.security import OAuth2PasswordRequestForm
+from fastapi_users import BaseUserManager, exceptions
 from fastapi_users.db import (
     BaseUserDatabase,
     BeanieUserDatabase,
@@ -14,7 +16,6 @@ from fastapi_users.db import (
 )
 from fastapi_users.password import PasswordHelperProtocol
 from beanie import PydanticObjectId
-from fastapi import Depends, Request
 import jinja2
 from .user_models import User
 from .auth import Settings
@@ -104,6 +105,35 @@ class UserManager(ObjectIDIDMixin, BaseUserManager[User, PydanticObjectId]):
                               request: Optional[Request] = None):
         """Handler to execute after user delete."""
         print(f"User {user.id} is successfully deleted")
+
+    async def authenticate(
+        self, credentials: OAuth2PasswordRequestForm
+    ) -> User | None:
+        """
+        Overload user authentication method `BaseUserManager.authenticate`.
+        This is to fix login endpoint to receive `username` instead of `email`.
+        """
+        try:
+            user = await User.find_one(User.username == credentials.username)
+        except exceptions.UserNotExists:
+            # Run the hasher to mitigate timing attack
+            # Inspired from Django: https://code.djangoproject.com/ticket/20760
+            self.password_helper.hash(credentials.password)
+            return None
+
+        verified, updated_password_hash = \
+            self.password_helper.verify_and_update(
+                credentials.password, user.hashed_password
+            )
+        if not verified:
+            return None
+        # Update password hash to a more robust one if needed
+        if updated_password_hash is not None:
+            await self.user_db.update(
+                user, {"hashed_password": updated_password_hash}
+            )
+
+        return user
 
 
 async def get_user_db():

--- a/api/user_manager.py
+++ b/api/user_manager.py
@@ -1,0 +1,116 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+#
+# Copyright (C) 2023 Collabora Limited
+# Author: Jeny Sadadia <jeny.sadadia@collabora.com>
+
+"""User Manager"""
+
+from typing import Optional, Any, Dict
+from fastapi_users import BaseUserManager
+from fastapi_users.db import (
+    BaseUserDatabase,
+    BeanieUserDatabase,
+    ObjectIDIDMixin,
+)
+from fastapi_users.password import PasswordHelperProtocol
+from beanie import PydanticObjectId
+from fastapi import Depends, Request
+import jinja2
+from .user_models import User
+from .auth import Settings
+from .email_sender import EmailSender
+
+
+class UserManager(ObjectIDIDMixin, BaseUserManager[User, PydanticObjectId]):
+    """User management logic"""
+    settings = Settings()
+    reset_password_token_secret = settings.secret_key
+    verification_token_secret = settings.secret_key
+
+    def __init__(self, user_db: BaseUserDatabase[User, PydanticObjectId],
+                 password_helper: PasswordHelperProtocol | None = None):
+        self._email_sender = EmailSender()
+        self._template_env = jinja2.Environment(
+                            loader=jinja2.FileSystemLoader(
+                                "./templates/")
+                        )
+        super().__init__(user_db, password_helper)
+
+    async def on_after_register(self, user: User,
+                                request: Optional[Request] = None):
+        """Handler to execute after successful user registration"""
+        print(f"User {user.id} has registered.")
+
+    async def on_after_request_verify(self, user: User, token: str,
+                                      request: Optional[Request] = None):
+        """Handler to execute after successful verification request"""
+        template = self._template_env.get_template("email-verification.jinja2")
+        subject = "Email verification Token for KernelCI API account"
+        content = template.render(
+            username=user.username, token=token
+        )
+        self._email_sender.create_and_send_email(subject, content, user.email)
+
+    async def on_after_verify(self, user: User,
+                              request: Optional[Request] = None):
+        """Handler to execute after successful user verification"""
+        print(f"Verification successful for user {user.id}")
+        template = self._template_env.get_template(
+            "email-verification-successful.jinja2")
+        subject = "Email verification successful for KernelCI API account"
+        content = template.render(
+            username=user.username,
+        )
+        self._email_sender.create_and_send_email(subject, content, user.email)
+
+    async def on_after_login(self, user: User,
+                             request: Optional[Request] = None):
+        """Handler to execute after successful user login"""
+        print(f"User {user.id} logged in.")
+
+    async def on_after_forgot_password(self, user: User, token: str,
+                                       request: Optional[Request] = None):
+        """Handler to execute after successful forgot password request"""
+        template = self._template_env.get_template("reset-password.jinja2")
+        subject = "Reset Password Token for KernelCI API account"
+        content = template.render(
+            username=user.username, token=token
+        )
+        self._email_sender.create_and_send_email(subject, content, user.email)
+
+    async def on_after_reset_password(self, user: User,
+                                      request: Optional[Request] = None):
+        """Handler to execute after successful password reset"""
+        print(f"User {user.id} has reset their password.")
+        template = self._template_env.get_template(
+            "reset-password-successful.jinja2")
+        subject = "Password reset successful for KernelCI API account"
+        content = template.render(
+            username=user.username,
+        )
+        self._email_sender.create_and_send_email(subject, content, user.email)
+
+    async def on_after_update(self, user: User, update_dict: Dict[str, Any],
+                              request: Optional[Request] = None):
+        """Handler to execute after successful user update"""
+        print(f"User {user.id} has been updated with {update_dict}.")
+
+    async def on_before_delete(self, user: User,
+                               request: Optional[Request] = None):
+        """Handler to execute before user delete."""
+        print(f"User {user.id} is going to be deleted.")
+
+    async def on_after_delete(self, user: User,
+                              request: Optional[Request] = None):
+        """Handler to execute after user delete."""
+        print(f"User {user.id} is successfully deleted")
+
+
+async def get_user_db():
+    """Database adapter for fastapi-users"""
+    yield BeanieUserDatabase(User)
+
+
+async def get_user_manager(user_db: BeanieUserDatabase = Depends(get_user_db)):
+    """Get user manager"""
+    yield UserManager(user_db)

--- a/api/user_models.py
+++ b/api/user_models.py
@@ -1,0 +1,54 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+#
+# Copyright (C) 2023 Collabora Limited
+# Author: Jeny Sadadia <jeny.sadadia@collabora.com>
+
+# Disable flag as user models don't require any public methods
+# at the moment
+# pylint: disable=too-few-public-methods
+
+"""User model definitions"""
+
+from typing import Optional
+from pydantic import conlist, Field
+from fastapi_users.db import BeanieBaseUser
+from fastapi_users import schemas
+from beanie import (
+    Indexed,
+    Document,
+    PydanticObjectId,
+)
+from .models import DatabaseModel, UserGroup, ModelId
+
+
+class User(BeanieBaseUser, Document,  # pylint: disable=too-many-ancestors
+           DatabaseModel):
+    """API User model"""
+    username: Indexed(str, unique=True)
+    groups: conlist(UserGroup, unique_items=True) = Field(
+        default=[],
+        description="A list of groups that user belongs to"
+    )
+
+    class Settings(BeanieBaseUser.Settings):
+        """Configurations"""
+        # MongoDB collection name for model
+        name = "user"
+
+
+class UserRead(schemas.BaseUser[PydanticObjectId], ModelId):
+    """Schema for reading a user"""
+    username: Indexed(str, unique=True)
+    groups: conlist(UserGroup, unique_items=True)
+
+
+class UserCreate(schemas.BaseUserCreate):
+    """Schema for creating a user"""
+    username: Indexed(str, unique=True)
+    groups: Optional[conlist(str, unique_items=True)]
+
+
+class UserUpdate(schemas.BaseUserUpdate):
+    """Schema for updating a user"""
+    username: Optional[Indexed(str, unique=True)]
+    groups: Optional[conlist(str, unique_items=True)]

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -16,6 +16,7 @@ services:
       - './api:/home/kernelci/api'
       - './tests:/home/kernelci/tests'
       - './migrations:/home/kernelci/migrations'
+      - './templates:/home/kernelci/templates'
     ports:
       - '${API_HOST_PORT:-8001}:8000'
     env_file:

--- a/docker/api/Dockerfile
+++ b/docker/api/Dockerfile
@@ -22,4 +22,4 @@ COPY requirements*.txt /home/kernelci/
 ARG REQUIREMENTS=requirements.txt
 RUN pip install --requirement ${REQUIREMENTS}
 
-CMD ["uvicorn", "api.main:app", "--host", "0.0.0.0", "--reload"]
+CMD ["uvicorn", "api.main:versioned_app", "--host", "0.0.0.0", "--reload"]

--- a/docker/api/requirements-tests.txt
+++ b/docker/api/requirements-tests.txt
@@ -6,3 +6,4 @@ pytest-dependency==0.5.1
 pytest-mock==3.6.1
 pytest-order==1.0.1
 httpx==0.23.3
+mongomock_motor==0.0.21

--- a/docker/api/requirements.txt
+++ b/docker/api/requirements.txt
@@ -11,3 +11,4 @@ pymongo-migrate==0.11.0
 pyyaml==5.3.1
 fastapi-versioning==0.10.0
 fastapi-users[beanie, oauth]==10.4.0
+MarkupSafe==2.0.1

--- a/docker/api/requirements.txt
+++ b/docker/api/requirements.txt
@@ -10,3 +10,4 @@ motor==2.5.1
 pymongo-migrate==0.11.0
 pyyaml==5.3.1
 fastapi-versioning==0.10.0
+fastapi-users[beanie, oauth]==10.4.0

--- a/templates/email-verification-successful.jinja2
+++ b/templates/email-verification-successful.jinja2
@@ -1,0 +1,8 @@
+{# SPDX-License-Identifier: LGPL-2.1-or-later -#}
+
+Hello {{ username }},
+
+Your email address has been verified successfully.
+
+Thanks,
+KernelCI SysAdmin

--- a/templates/email-verification.jinja2
+++ b/templates/email-verification.jinja2
@@ -1,0 +1,10 @@
+{# SPDX-License-Identifier: LGPL-2.1-or-later -#}
+
+Hello {{ username }},
+
+The token for verifying your email address for KernelCI API account is:
+
+  {{ token }}
+
+Thanks,
+KernelCI SysAdmin

--- a/templates/reset-password-successful.jinja2
+++ b/templates/reset-password-successful.jinja2
@@ -1,0 +1,8 @@
+{# SPDX-License-Identifier: LGPL-2.1-or-later -#}
+
+Hello {{ username }},
+
+Your password reset is successful.
+
+Thanks,
+KernelCI SysAdmin

--- a/templates/reset-password.jinja2
+++ b/templates/reset-password.jinja2
@@ -1,0 +1,10 @@
+{# SPDX-License-Identifier: LGPL-2.1-or-later -#}
+
+Hello {{ username }},
+
+The token to reset your password for KernelCI API account is:
+
+  {{ token }}
+
+Thanks,
+KernelCI SysAdmin

--- a/tests/e2e_tests/conftest.py
+++ b/tests/e2e_tests/conftest.py
@@ -12,7 +12,7 @@ from motor.motor_asyncio import AsyncIOMotorClient
 
 from fastapi.testclient import TestClient
 
-from api.main import app
+from api.main import versioned_app
 
 BASE_URL = 'http://api:8000/latest/'
 DB_URL = 'mongodb://db:27017'
@@ -25,17 +25,17 @@ db = db_client[DB_NAME]
 @pytest.fixture(scope='session')
 def test_client():
     """Fixture to get FastAPI Test client instance"""
-    with TestClient(app=app, base_url=BASE_URL) as client:
+    with TestClient(app=versioned_app, base_url=BASE_URL) as client:
         yield client
 
 
 @pytest.fixture(scope='session')
 async def test_async_client():
     """Fixture to get Test client for asynchronous tests"""
-    async with AsyncClient(app=app, base_url=BASE_URL) as client:
-        await app.router.startup()
+    async with AsyncClient(app=versioned_app, base_url=BASE_URL) as client:
+        await versioned_app.router.startup()
         yield client
-        await app.router.shutdown()
+        await versioned_app.router.shutdown()
 
 
 async def db_create(collection, obj):

--- a/tests/e2e_tests/test_password_handler.py
+++ b/tests/e2e_tests/test_password_handler.py
@@ -2,6 +2,7 @@
 #
 # Copyright (C) 2023 Collabora Limited
 # Author: Paweł Wieczorek <pawel.wieczorek@collabora.com>
+# Author: Jeny Sadadia <jeny.sadadia@collabora.com>
 
 """End-to-end test functions for KernelCI API password reset handler"""
 
@@ -17,17 +18,20 @@ import pytest
 @pytest.mark.asyncio
 async def test_password_endpoint(test_async_client):
     """
-    Test Case : Test KernelCI API /password endpoint to set a new password
-    when requested with current user's password
+    Test Case : Test KernelCI API /user/me endpoint to set a new password
+    when requested with current user's access token
     Expected Result :
         HTTP Response Code 200 OK
     """
-    response = await test_async_client.post(
-        "password?username=test_user",
+    response = await test_async_client.patch(
+        "user/me",
+        headers={
+            "Accept": "application/json",
+            "Authorization": f"Bearer {pytest.BEARER_TOKEN}"
+        },
         data=json.dumps(
             {
-                "current_password": {"password": "test"},
-                "new_password": {"password": "foo"},
+                "password": "foo"
             }
         ),
     )

--- a/tests/unit_tests/test_listen_handler.py
+++ b/tests/unit_tests/test_listen_handler.py
@@ -13,8 +13,7 @@
 from tests.unit_tests.conftest import BEARER_TOKEN
 
 
-def test_listen_endpoint(mock_get_current_user,
-                         mock_listen, test_client):
+def test_listen_endpoint(mock_listen, test_client):
     """
     Test Case : Test KernelCI API GET /listen endpoint for the
     positive path
@@ -33,8 +32,7 @@ def test_listen_endpoint(mock_get_current_user,
     assert response.status_code == 200
 
 
-def test_listen_endpoint_not_found(mock_get_current_user,
-                                   test_client):
+def test_listen_endpoint_not_found(test_client):
     """
     Test Case : Test KernelCI API GET /listen endpoint for the
     negative path
@@ -53,8 +51,7 @@ def test_listen_endpoint_not_found(mock_get_current_user,
     assert 'detail' in response.json()
 
 
-def test_listen_endpoint_without_token(mock_get_current_user,
-                                       test_client):
+def test_listen_endpoint_without_token(test_client):
     """
     Test Case : Test KernelCI API GET /listen endpoint for the
     negative path

--- a/tests/unit_tests/test_node_handler.py
+++ b/tests/unit_tests/test_node_handler.py
@@ -17,8 +17,7 @@ from api.models import Node, Revision
 from api.paginator_models import PageModel
 
 
-def test_create_node_endpoint(mock_get_current_user,
-                              mock_db_create, mock_publish_cloudevent,
+def test_create_node_endpoint(mock_db_create, mock_publish_cloudevent,
                               test_client):
     """
     Test Case : Test KernelCI API /node endpoint
@@ -91,8 +90,7 @@ def test_create_node_endpoint(mock_get_current_user,
     }
 
 
-def test_get_nodes_by_attributes_endpoint(mock_get_current_user,
-                                          mock_db_find_by_attributes,
+def test_get_nodes_by_attributes_endpoint(mock_db_find_by_attributes,
                                           test_client):
     """
     Test Case : Test KernelCI API GET /nodes?attribute_name=attribute_value
@@ -159,7 +157,6 @@ def test_get_nodes_by_attributes_endpoint(mock_get_current_user,
 
 
 def test_get_nodes_by_attributes_endpoint_node_not_found(
-        mock_get_current_user,
         mock_db_find_by_attributes,
         test_client):
     """
@@ -190,7 +187,7 @@ def test_get_nodes_by_attributes_endpoint_node_not_found(
     assert response.json().get('total') == 0
 
 
-def test_get_node_by_id_endpoint(mock_get_current_user, mock_db_find_by_id,
+def test_get_node_by_id_endpoint(mock_db_find_by_id,
                                  test_client):
     """
     Test Case : Test KernelCI API GET /node/{node_id} endpoint
@@ -244,8 +241,7 @@ def test_get_node_by_id_endpoint(mock_get_current_user, mock_db_find_by_id,
     }
 
 
-def test_get_node_by_id_endpoint_empty_response(mock_get_current_user,
-                                                mock_db_find_by_id,
+def test_get_node_by_id_endpoint_empty_response(mock_db_find_by_id,
                                                 test_client):
     """
     Test Case : Test KernelCI API GET /node/{node_id} endpoint
@@ -262,7 +258,7 @@ def test_get_node_by_id_endpoint_empty_response(mock_get_current_user,
     assert response.json() is None
 
 
-def test_get_all_nodes(mock_get_current_user, mock_db_find_by_attributes,
+def test_get_all_nodes(mock_db_find_by_attributes,
                        test_client):
     """
     Test Case : Test KernelCI API GET /nodes endpoint for the
@@ -343,8 +339,7 @@ def test_get_all_nodes(mock_get_current_user, mock_db_find_by_attributes,
     assert len(response.json()) > 0
 
 
-def test_get_all_nodes_empty_response(mock_get_current_user,
-                                      mock_db_find_by_attributes,
+def test_get_all_nodes_empty_response(mock_db_find_by_attributes,
                                       test_client):
     """
     Test Case : Test KernelCI API GET /nodes endpoint for the

--- a/tests/unit_tests/test_subscribe_handler.py
+++ b/tests/unit_tests/test_subscribe_handler.py
@@ -11,8 +11,7 @@ from tests.unit_tests.conftest import BEARER_TOKEN
 from api.pubsub import Subscription
 
 
-def test_subscribe_endpoint(mock_get_current_user,
-                            mock_subscribe, test_client):
+def test_subscribe_endpoint(mock_subscribe, test_client):
     """
     Test Case : Test KernelCI API /subscribe endpoint
     Expected Result :

--- a/tests/unit_tests/test_token_handler.py
+++ b/tests/unit_tests/test_token_handler.py
@@ -10,96 +10,65 @@
 
 """Unit test function for KernelCI API token handler"""
 
-from api.models import User, UserGroup, UserProfile
+import pytest
+from fastapi_users.exceptions import UserNotExists
+from api.user_models import User
 
 
-def test_token_endpoint(mock_db_find_one_by_attributes,
-                        test_client):
+@pytest.mark.asyncio
+async def test_token_endpoint(test_async_client, mock_user_find):
     """
-    Test Case : Test KernelCI API token endpoint
+    Test Case : Test KernelCI API /user/login endpoint
     Expected Result :
         HTTP Response Code 200 OK
         JSON with 'access_token' and 'token_type' key
     """
-    profile = UserProfile(
+    user = User(
+        id='65265305c74695807499037f',
         username='bob',
         hashed_password='$2b$12$CpJZx5ooxM11bCFXT76/z.o6HWs2sPJy4iP8.'
                         'xCZGmM8jWXUXJZ4K',
         email='bob@kernelci.org',
-        groups=[]
+        groups=[],
+        is_active=True,
+        is_superuser=False,
+        is_verified=True
     )
-    user = User(profile=profile, active=True)
-    mock_db_find_one_by_attributes.return_value = user
-    response = test_client.post(
-        "token",
+    mock_user_find.return_value = user
+    response = await test_async_client.post(
+        "user/login",
         headers={
             "Accept": "application/json",
             "Content-Type": "application/x-www-form-urlencoded"
         },
-        data={'username': 'bob', 'password': 'hello'}
+        data="username=bob&password=hello"
     )
-    print("json", response.json())
     assert response.status_code == 200
     assert ('access_token', 'token_type') == tuple(response.json().keys())
 
 
-def test_token_endpoint_incorrect_password(mock_db_find_one_by_attributes,
-                                           test_client):
+@pytest.mark.asyncio
+async def test_token_endpoint_incorrect_password(test_async_client,
+                                                 mock_user_find):
     """
-    Test Case : Test KernelCI API token endpoint for negative path
+    Test Case : Test KernelCI API /user/login endpoint for negative path
     Incorrect password should be passed to the endpoint
 
     Expected Result :
-        HTTP Response Code 401 Unauthorized
+        HTTP Response Code 400 Bad Request
         JSON with 'detail' key
     """
-    profile = UserProfile(
-        username='bob',
-        hashed_password='$2b$12$CpJZx5ooxM11bCFXT76/z.o6HWs2sPJy4iP8.'
-                        'xCZGmM8jWXUXJZ4K',
-        email='bob@kernelci.org',
-        groups=[])
-    user = User(profile=profile, active=True)
-    mock_db_find_one_by_attributes.return_value = user
+    mock_user_find.side_effect = UserNotExists
 
     # Pass incorrect password
-    response = test_client.post(
-        "token",
+    response = await test_async_client.post(
+        "user/login",
         headers={
             "Accept": "application/json",
             "Content-Type": "application/x-www-form-urlencoded"
         },
-        data={'username': 'bob', 'password': 'hi'}
+        data="username=bob&password=hello1"
     )
     print("response json", response.json())
-    assert response.status_code == 401
-    assert response.json() == {'detail': 'Incorrect username or password'}
-
-
-def test_token_endpoint_admin_user(mock_db_find_one_by_attributes,
-                                   test_client):
-    """
-    Test Case : Test KernelCI API token endpoint for admin user
-    Expected Result :
-        HTTP Response Code 200 OK
-        JSON with 'access_token' and 'token_type' key
-    """
-    profile = UserProfile(
-        username='test_admin',
-        hashed_password='$2b$12$CpJZx5ooxM11bCFXT76/z.o6HWs2sPJy4iP8.'
-                        'xCZGmM8jWXUXJZ4K',
-        email='test-admin@kernelci.org',
-        groups=[UserGroup(name='admin')])
-    user = User(profile=profile, active=True)
-    mock_db_find_one_by_attributes.return_value = user
-    response = test_client.post(
-        "token",
-        headers={
-            "Accept": "application/json",
-            "Content-Type": "application/x-www-form-urlencoded"
-        },
-        data={'username': 'test_admin', 'password': 'hello', 'scope': 'admin'}
-    )
-    print("json", response.json())
-    assert response.status_code == 200
-    assert ('access_token', 'token_type') == tuple(response.json().keys())
+    assert response.status_code == 400
+    assert response.json() == {'detail': 'LOGIN_BAD_CREDENTIALS'}

--- a/tests/unit_tests/test_unsubscribe_handler.py
+++ b/tests/unit_tests/test_unsubscribe_handler.py
@@ -10,8 +10,7 @@
 from tests.unit_tests.conftest import BEARER_TOKEN
 
 
-def test_unsubscribe_endpoint(mock_get_current_user,
-                              mock_unsubscribe, test_client):
+def test_unsubscribe_endpoint(mock_unsubscribe, test_client):
     """
     Test Case : Test KernelCI API /unsubscribe endpoint positive path
     Expected Result :
@@ -26,8 +25,7 @@ def test_unsubscribe_endpoint(mock_get_current_user,
     assert response.status_code == 200
 
 
-def test_unsubscribe_endpoint_empty_response(mock_get_current_user,
-                                             test_client):
+def test_unsubscribe_endpoint_empty_response(test_client):
     """
     Test Case : Test KernelCI API /unsubscribe endpoint negative path
     Expected Result :

--- a/tests/unit_tests/test_user_group_handler.py
+++ b/tests/unit_tests/test_user_group_handler.py
@@ -17,8 +17,7 @@ from api.models import UserGroup
 from api.paginator_models import PageModel
 
 
-def test_create_user_group(mock_get_current_admin_user,
-                           mock_db_create, mock_publish_cloudevent,
+def test_create_user_group(mock_db_create, mock_publish_cloudevent,
                            test_client):
     """
     Test Case : Test KernelCI API /group endpoint to create user group
@@ -44,18 +43,15 @@ def test_create_user_group(mock_get_current_admin_user,
     assert ('id', 'name') == tuple(response.json().keys())
 
 
-def test_create_group_endpoint_negative(mock_get_current_user,
-                                        mock_publish_cloudevent,
+def test_create_group_endpoint_negative(mock_publish_cloudevent,
                                         test_client):
     """
     Test Case : Test KernelCI API /group endpoint when requested
     with regular user's bearer token
     Expected Result :
-        HTTP Response Code 401 Unauthorized
-        JSON with 'detail' key denoting 'Access denied' error
+        HTTP Response Code 403 Forbidden
+        JSON with 'detail' key denoting 'Forbidden' error
     """
-    mock_get_current_user.return_value = None, "Access denied"
-
     response = test_client.post(
         "group",
         headers={
@@ -65,8 +61,8 @@ def test_create_group_endpoint_negative(mock_get_current_user,
         data=json.dumps({"name": "kernelci"})
     )
     print(response.json())
-    assert response.status_code == 401
-    assert response.json() == {'detail': 'Access denied'}
+    assert response.status_code == 403
+    assert response.json() == {'detail': 'Forbidden'}
 
 
 def test_get_groups(mock_db_find_by_attributes,

--- a/tests/unit_tests/test_user_handler.py
+++ b/tests/unit_tests/test_user_handler.py
@@ -8,145 +8,172 @@
 """Unit test function for KernelCI API user handler"""
 
 import json
+import pytest
 
 from tests.unit_tests.conftest import (
     ADMIN_BEARER_TOKEN,
     BEARER_TOKEN,
 )
-from api.models import User, UserGroup, UserProfile
+from api.models import UserGroup
+from api.user_models import UserRead
 
 
-def test_create_regular_user(mock_get_current_admin_user,
-                             mock_db_create, mock_publish_cloudevent,
-                             test_client):
+@pytest.mark.asyncio
+async def test_create_regular_user(mock_db_find_one, mock_db_create,
+                                   test_async_client):
     """
-    Test Case : Test KernelCI API /user endpoint to create regular user
-    when requested with admin user's bearer token
+    Test Case : Test KernelCI API /user/register endpoint to create regular
+    user when requested with admin user's bearer token
     Expected Result :
         HTTP Response Code 200 OK
-        JSON with 'id', 'username', 'hashed_password', and
-        'active' keys
+        JSON with 'id', 'username', 'email', 'groups', 'is_active'
+        'is_verified' and 'is_superuser' keys
     """
-    profile = UserProfile(username='test', hashed_password="$2b$12$Whi.dpTC.\
-HR5UHMdMFQeOe1eD4oXaP08oW7ogYqyiNziZYNdUHs8i", email='test@kernelci.org')
-    user = User(profile=profile, active=True)
+    mock_db_find_one.return_value = None
+    user = UserRead(
+        id='65265305c74695807499037f',
+        username='test',
+        email='test@kernelci.org',
+        groups=[],
+        is_active=True,
+        is_verified=False,
+        is_superuser=False
+    )
     mock_db_create.return_value = user
 
-    response = test_client.post(
-        "user/test?email=test@kernelci.org",
+    response = await test_async_client.post(
+        "user/register",
         headers={
             "Accept": "application/json",
             "Authorization": ADMIN_BEARER_TOKEN
         },
-        data=json.dumps({"password": "test"})
+        data=json.dumps({
+            'username': 'test',
+            'password': 'test',
+            'email': 'test@kernelci.org'
+        })
     )
     print(response.json())
     assert response.status_code == 200
-    assert ('id', 'active', 'profile') == tuple(response.json().keys())
-    assert ('username', 'hashed_password',
-            'groups', 'email') == tuple(response.json()['profile'].keys())
+    assert ('id', 'email', 'is_active', 'is_superuser', 'is_verified',
+            'username', 'groups') == tuple(response.json().keys())
 
 
-def test_create_admin_user(  # pylint: disable=too-many-arguments
-                           mock_get_current_admin_user,
-                           mock_db_create, mock_publish_cloudevent,
-                           test_client, mock_db_find_one):
+@pytest.mark.asyncio
+async def test_create_admin_user(test_async_client, mock_db_find_one,
+                                 mock_db_find_by_id, mock_db_update):
     """
-    Test Case : Test KernelCI API /user endpoint to create admin user
+    Test Case : Test KernelCI API /user/register endpoint to create admin user
     when requested with admin user's bearer token
     Expected Result :
         HTTP Response Code 200 OK
-        JSON with 'id', 'username', 'hashed_password', and
-        'active' keys
+        JSON with 'id', 'username', 'email', 'groups', 'is_active'
+        'is_verified' and 'is_superuser' keys
     """
-    profile = UserProfile(
+    user = UserRead(
+        id='61bda8f2eb1a63d2b7152419',
         username='test_admin',
-        hashed_password="$2b$12$Whi.dpTC.HR5UHMdMFQeOe1eD4oXaP08o\
-W7ogYqyiNziZYNdUHs8i",
         email='test-admin@kernelci.org',
-        groups=[UserGroup(name='admin')])
-    user = User(profile=profile, active=True)
-    mock_db_create.return_value = user
-    mock_db_find_one.return_value = UserGroup(name='admin')
+        groups=[UserGroup(name='admin')],
+        is_active=True,
+        is_verified=False,
+        is_superuser=True
+    )
+    mock_db_find_one.return_value = None
+    mock_db_find_by_id.return_value = user
+    mock_db_update.return_value = user
 
-    response = test_client.post(
-        "user/test_admin?groups=admin&email=test-admin@kernelci.org",
+    response = await test_async_client.post(
+        "user/register",
         headers={
             "Accept": "application/json",
             "Authorization": ADMIN_BEARER_TOKEN
         },
-        data=json.dumps({"password": "test"})
+        data=json.dumps({
+            'username': 'test_admin',
+            'password': 'test',
+            'email': 'test-admin@kernelci.org',
+            'is_superuser': True
+        })
     )
     print(response.json())
     assert response.status_code == 200
-    assert ('id', 'active', 'profile') == tuple(response.json().keys())
-    assert ('username', 'hashed_password',
-            'groups', 'email') == tuple(response.json()['profile'].keys())
+    assert ('id', 'email', 'is_active', 'is_superuser', 'is_verified',
+            'username', 'groups') == tuple(response.json().keys())
 
 
-def test_create_user_endpoint_negative(mock_get_current_user,
-                                       mock_publish_cloudevent, test_client):
+@pytest.mark.asyncio
+async def test_create_user_endpoint_negative(test_async_client):
     """
-    Test Case : Test KernelCI API /user endpoint when requested
+    Test Case : Test KernelCI API /user/register endpoint when requested
     with regular user's bearer token
     Expected Result :
         HTTP Response Code 401 Unauthorized
-        JSON with 'detail' key denoting 'Access denied' error
+        JSON with 'detail' key denoting 'Forbidden' error
     """
-    mock_get_current_user.return_value = None, "Access denied"
-
-    response = test_client.post(
-        "user/test",
+    response = await test_async_client.post(
+        "user/register",
         headers={
             "Accept": "application/json",
             "Authorization": BEARER_TOKEN
         },
-        data=json.dumps({"password": "test"})
+        data=json.dumps({
+            'username': 'test',
+            'password': 'test',
+            'email': 'test@kernelci.org'
+        })
     )
     print(response.json())
-    assert response.status_code == 401
-    assert response.json() == {'detail': 'Access denied'}
+    assert response.status_code == 403
+    assert response.json() == {'detail': 'Forbidden'}
 
 
-def test_create_user_with_group(  # pylint: disable=too-many-arguments
-                           mock_get_current_admin_user,
-                           mock_db_create, mock_publish_cloudevent,
-                           test_client, mock_db_find_one):
+@pytest.mark.asyncio
+async def test_create_user_with_group(test_async_client, mock_db_find_one,
+                                      mock_db_update,mock_db_find_by_id):
     """
-    Test Case : Test KernelCI API /user endpoint to create a user with a
-    user group
+    Test Case : Test KernelCI API /user/register endpoint to create a user
+    with a user group
     Expected Result :
         HTTP Response Code 200 OK
-        JSON with 'id', 'username', 'hashed_password'
-        'active', and 'groups' keys
+        JSON with 'id', 'username', 'email', 'groups', 'is_active'
+        'is_verified' and 'is_superuser' keys
     """
-    profile = UserProfile(
+    user = UserRead(
+        id='61bda8f2eb1a63d2b7152419',
         username='test_admin',
-        hashed_password="$2b$12$Whi.dpTC.HR5UHMdMFQeOe1eD4oXaP08oW7\
-ogYqyiNziZYNdUHs8i",
         email='test-admin@kernelci.org',
-        groups=[UserGroup(name='kernelci')])
-    user = User(profile=profile, active=True)
-    mock_db_create.return_value = user
-    mock_db_find_one.return_value = UserGroup(name='kernelci')
+        groups=[UserGroup(name='kernelci')],
+        is_active=True,
+        is_verified=False,
+        is_superuser=False
+    )
+    mock_db_find_by_id.return_value = user
+    mock_db_update.return_value = user
+    mock_db_find_one.side_effect = [None, UserGroup(name='kernelci')]
 
-    response = test_client.post(
-        "user/test_admin?groups=kernelci&email=test-admin@kernelci.org",
+    response = await test_async_client.post(
+        "user/register",
         headers={
             "Accept": "application/json",
             "Authorization": ADMIN_BEARER_TOKEN
         },
-        data=json.dumps({"password": "test"})
+        data=json.dumps({
+            'username': 'test',
+            'password': 'test',
+            'email': 'test-admin@kernelci.org',
+            'groups': ['kernelci']
+        })
     )
     print(response.json())
     assert response.status_code == 200
-    assert ('id', 'active', 'profile') == tuple(response.json().keys())
-    assert ('username', 'hashed_password',
-            'groups', 'email') == tuple(response.json()['profile'].keys())
+    assert ('id', 'email', 'is_active', 'is_superuser', 'is_verified',
+            'username', 'groups') == tuple(response.json().keys())
 
 
-def test_get_user_by_id_endpoint(mock_get_current_admin_user, mock_db_find_by_id,
-                                 test_client):
+@pytest.mark.asyncio
+async def test_get_user_by_id_endpoint(test_async_client,
+                                       mock_beanie_get_user_by_id):
     """
     Test Case : Test KernelCI API GET /user/{user_id} endpoint with admin
     token
@@ -154,15 +181,18 @@ def test_get_user_by_id_endpoint(mock_get_current_admin_user, mock_db_find_by_id
         HTTP Response Code 200 OK
         JSON with User object attributes
     """
-    user_obj = User(
+    user_obj = UserRead(
             id='61bda8f2eb1a63d2b7152418',
-            profile=UserProfile(username='test', hashed_password="$2b$12$Whi.dpTC.\
-HR5UHMdMFQeOe1eD4oXaP08oW7ogYqyiNziZYNdUHs8i", email='test@kernelci.org'),
-            active=True
+            username='test',
+            email='test@kernelci.org',
+            groups=[],
+            is_active=True,
+            is_verified=False,
+            is_superuser=False
         )
-    mock_db_find_by_id.return_value = user_obj
+    mock_beanie_get_user_by_id.return_value = user_obj
 
-    response = test_client.get(
+    response = await test_async_client.get(
         "user/61bda8f2eb1a63d2b7152418",
         headers={
             "Accept": "application/json",
@@ -170,10 +200,5 @@ HR5UHMdMFQeOe1eD4oXaP08oW7ogYqyiNziZYNdUHs8i", email='test@kernelci.org'),
         })
     print("response.json()", response.json())
     assert response.status_code == 200
-    assert response.json().keys() == {
-        'id',
-        'active',
-        'profile'
-    }
-    assert ('username', 'groups',
-            'email') == tuple(response.json()['profile'].keys())
+    assert ('id', 'email', 'is_active', 'is_superuser', 'is_verified',
+            'username', 'groups') == tuple(response.json().keys())

--- a/tests/unit_tests/test_whoami_handler.py
+++ b/tests/unit_tests/test_whoami_handler.py
@@ -10,10 +10,13 @@
 
 """Unit test function for KernelCI API whoami handler"""
 
+import pytest
 from tests.unit_tests.conftest import BEARER_TOKEN
+from api.user_models import UserRead
 
 
-def test_whoami_endpoint(mock_get_current_user, test_client):
+@pytest.mark.asyncio
+async def test_whoami_endpoint(test_async_client, mock_auth_current_user):
     """
     Test Case : Test KernelCI API /whoami endpoint
     Expected Result :
@@ -21,12 +24,25 @@ def test_whoami_endpoint(mock_get_current_user, test_client):
         JSON with 'id', 'username', 'hashed_password'
         and 'active' keys
     """
-    response = test_client.get(
+    user = UserRead(
+            id='61bda8f2eb1a63d2b7152420',
+            username='test-user',
+            email='test-user@kernelci.org',
+            groups=[],
+            is_active=True,
+            is_verified=False,
+            is_superuser=False
+        )
+    mock_auth_current_user.return_value = user, BEARER_TOKEN
+    response = await test_async_client.get(
         "whoami",
         headers={
             "Accept": "application/json",
             "Authorization": BEARER_TOKEN
         },
     )
+    print(response.json(), response.status_code)
     assert response.status_code == 200
-    assert ('id', 'active', 'profile') == tuple(response.json().keys())
+    assert ('id', 'email', 'is_active', 'is_superuser',
+            'is_verified', 'username',
+            'groups') == tuple(response.json().keys())


### PR DESCRIPTION
On top of https://github.com/kernelci/kernelci-api/pull/377

api: add `api.config` to define various module settings
    
Instead of defining multiple settings class in different API modules like `pubsub`, `auth`, `email_sender`, add `api.config` module to store all different settings classes.
