### PR TITLE
Rework models

### DIFF
--- a/api/db.py
+++ b/api/db.py
@@ -10,7 +10,7 @@ from bson import ObjectId
 from beanie import init_beanie
 from fastapi_pagination.ext.motor import paginate
 from motor import motor_asyncio
-from kernelci.api.models import Hierarchy, Node, Regression
+from kernelci.api.models import Hierarchy, Node
 from .models import User, UserGroup
 
 
@@ -25,7 +25,6 @@ class Database:
     COLLECTIONS = {
         User: 'user',
         Node: 'node',
-        Regression: 'regression',
         UserGroup: 'usergroup',
     }
 

--- a/api/main.py
+++ b/api/main.py
@@ -433,7 +433,6 @@ def _get_node_event_data(operation, node):
         'group': node.group,
         'state': node.state,
         'result': node.result,
-        'revision': node.revision.dict(),
         'owner': node.owner,
     }
 

--- a/api/main.py
+++ b/api/main.py
@@ -427,12 +427,14 @@ def _get_node_event_data(operation, node):
     return {
         'op': operation,
         'id': str(node.id),
+        'kind': node.kind,
         'name': node.name,
         'path': node.path,
         'group': node.group,
         'state': node.state,
         'result': node.result,
         'owner': node.owner,
+        'data': node.data,
     }
 
 

--- a/migrations/20231215122000_node_models.py
+++ b/migrations/20231215122000_node_models.py
@@ -1,0 +1,137 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+#
+# Copyright (C) 2023 Collabora Limited
+# Author: Ricardo Cañuelo <ricardo.canuelo@collabora.com>
+
+"""Migration for Node objects to comply with the models after commits:
+
+    api.models: basic definitions of Node submodels
+    api.main: use node endpoints for all type of Node subtypes
+    api.db: remove regression collection
+
+"""
+
+from bson.objectid import ObjectId
+
+name = '20231215122000_node_models'
+dependencies = ['20231102101356_user']
+
+
+def node_upgrade_needed(node):
+    """Checks if a DB Node passed as a parameter needs to be migrated
+    with this script.
+
+    Parameters:
+      user: a mongodb document (dict) defining a KernelCI Node
+
+    Returns:
+      True if the node needs to be migrated, False otherwise
+
+    """
+    # The existence of a 'revision' key seems to be enough to detect a
+    # pre-migration Node
+    if 'revision' in node:
+        return True
+    else:
+        return False
+
+
+def upgrade(db: "pymongo.database.Database"):
+    # Update nodes
+    nodes = db.node.find()
+    for node in nodes:
+        # Skip any node that's not in the old format
+        if not node_upgrade_needed(node):
+            continue
+        if not node.get('data'):
+            # Initialize 'data' field if it's empty: a generic Node
+            # with no specific type may have an emtpy 'data' field
+            db.node.update_one(
+                {'_id': node['_id']},
+                {'$set': {'data': {}}}
+            )
+        # move 'revision' to 'data.kernel_revision'
+        db.node.update_one(
+            {'_id': node['_id']},
+            {
+                '$set': {
+                    'data.kernel_revision': node['revision']
+                },
+                '$unset': {'revision': ''}
+            }
+        )
+
+    # Re-format regressions: move them from "regression" to "node"
+    regressions = db.regression.find()
+    for regression in regressions:
+        db.node.insert_one(
+            {
+                'name': regression.get('name'),
+                'group': regression.get('group'),
+                'path': regression.get('path'),
+                'kind': 'regression',
+                'data': {
+                    'pass_node': ObjectId(regression['regression_data'][0]),
+                    'fail_node': ObjectId(regression['regression_data'][1])
+                },
+                'artifacts': regression.get('artifacts'),
+                'created': regression.get('created'),
+                'updated': regression.get('updated'),
+                'timeout': regression.get('timeout'),
+                'owner': regression.get('owner'),
+            }
+        )
+        db.regression.delete_one({'_id': regression['_id']})
+
+
+def downgrade(db: 'pymongo.database.Database'):
+    # Move regressions back to "regression"
+    regressions = db.node.find({'kind': 'regression'})
+    for regression in regressions:
+        fail_node = db.node.find_one(
+            {'_id': ObjectId(regression['data']['fail_node'])}
+        )
+        db.regression.insert_one(
+            {
+                'name': regression.get('name'),
+                'group': regression.get('group'),
+                'path': regression.get('path'),
+                'kind': 'regression',
+                'parent': regression['data']['fail_node'],
+                'regression_data': [
+                    regression['data']['pass_node'],
+                    regression['data']['fail_node']
+                ],
+                'revision': fail_node['data']['kernel_revision'],
+                'artifacts': regression.get('artifacts'),
+                'created': regression.get('created'),
+                'updated': regression.get('updated'),
+                'timeout': regression.get('timeout'),
+                'owner': regression.get('owner'),
+            }
+        )
+        db.node.delete_one({'_id': regression['_id']})
+
+    # Downgrade node format
+    nodes = db.node.find()
+    for node in nodes:
+        # Skip any node that's already in the old format
+        if node_upgrade_needed(node):
+            continue
+        # move 'data.kernel_revision' to 'revision'
+        db.node.update_one(
+            {'_id': node['_id']},
+            {
+                '$set': {
+                    'revision': node['data']['kernel_revision']
+                },
+                '$unset': {'data.kernel_revision': ''}
+            }
+        )
+        # unset 'data' if it's empty
+        node['data'].pop('kernel_revision', None)
+        if len(node['data']) == 0:
+            db.node.update_one(
+                {'_id': node['_id']},
+                {'$unset': {'data': ''}}
+            )

--- a/tests/e2e_tests/test_pipeline.py
+++ b/tests/e2e_tests/test_pipeline.py
@@ -59,8 +59,8 @@ async def test_node_pipeline(test_async_client):
     await task_listen
     event_data = from_json(task_listen.result().json().get('data')).data
     assert event_data != 'BEEP'
-    keys = {'op', 'id', 'name', 'path', 'group', 'state', 'result', 'revision',
-            'owner'}
+    keys = {'op', 'id', 'kind', 'name', 'path',
+            'group', 'state', 'result', 'owner', 'data'}
     assert keys == event_data.keys()
     assert event_data.get('op') == 'created'
     assert event_data.get('id') == response.json()['id']
@@ -82,7 +82,7 @@ async def test_node_pipeline(test_async_client):
     await task_listen
     event_data = from_json(task_listen.result().json().get('data')).data
     assert event_data != 'BEEP'
-    keys = {'op', 'id', 'name', 'path', 'group', 'state', 'result', 'revision',
-            'owner'}
+    keys = {'op', 'id', 'kind', 'name', 'path',
+            'group', 'state', 'result', 'owner', 'data'}
     assert keys == event_data.keys()
     assert event_data.get('op') == 'updated'

--- a/tests/unit_tests/test_node_handler.py
+++ b/tests/unit_tests/test_node_handler.py
@@ -94,16 +94,17 @@ def test_get_nodes_by_attributes_endpoint(mock_db_find_by_attributes,
     """
     node_obj_1 = {
         "id": "61bda8f2eb1a63d2b7152418",
-        "kind": "node",
+        "kind": "checkout",
         "name": "checkout",
         "path": ["checkout"],
-        "revision": {
-            "tree": "mainline",
-            "url": "https://git.kernel.org/pub/scm/linux/kernel/git/"
-                    "torvalds/linux.git",
-            "branch": "master",
-            "commit": "2a987e65025e2b79c6d453b78cb5985ac6e5eb26",
-            "describe": "v5.16-rc4-31-g2a987e65025e",
+        "data": {
+            "kernel_revision": {
+                "tree": "mainline",
+                "url": "https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git",
+                "branch": "master",
+                "commit": "2a987e65025e2b79c6d453b78cb5985ac6e5eb26",
+                "describe": "v5.16-rc4-31-g2a987e65025e",
+            },
         },
         "parent": "61bda8f2eb1a63d2b7152410",
         "state": "closing",
@@ -111,16 +112,17 @@ def test_get_nodes_by_attributes_endpoint(mock_db_find_by_attributes,
     }
     node_obj_2 = {
         "id": "61bda8f2eb1a63d2b7152414",
-        "kind": "node",
+        "kind": "checkout",
         "name": "checkout",
         "path": ["checkout"],
-        "revision": {
-            "tree": "mainline",
-            "url": "https://git.kernel.org/pub/scm/linux/kernel/git/"
-                "torvalds/linux.git",
-            "branch": "master",
-            "commit": "2a987e65025e2b79c6d453b78cb5985ac6e5eb45",
-            "describe": "v5.16-rc4-31-g2a987e65025e",
+        "data": {
+            "kernel_revision": {
+                "tree": "mainline",
+                "url": "https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git",
+                "branch": "master",
+                "commit": "2a987e65025e2b79c6d453b78cb5985ac6e5eb45",
+                "describe": "v5.16-rc4-31-g2a987e65025e",
+            },
         },
         "parent": "61bda8f2eb1a63d2b7152410",
         "state": "closing",
@@ -135,8 +137,8 @@ def test_get_nodes_by_attributes_endpoint(mock_db_find_by_attributes,
 
     params = {
         "name": "checkout",
-        "revision.tree": "mainline",
-        "revision.branch": "master",
+        "data.kernel_revision.tree": "mainline",
+        "data.kernel_revision.branch": "master",
         "state": "closing",
         "parent": "61bda8f2eb1a63d2b7152410",
     }

--- a/tests/unit_tests/test_node_handler.py
+++ b/tests/unit_tests/test_node_handler.py
@@ -25,39 +25,33 @@ def test_create_node_endpoint(mock_db_create, mock_publish_cloudevent,
         HTTP Response Code 200 OK
         JSON with created Node object attributes
     """
-    revision_obj = Revision(
-                tree="mainline",
-                url="https://git.kernel.org/pub/scm/linux/kernel/git/"
-                    "torvalds/linux.git",
-                branch="master",
-                commit="2a987e65025e2b79c6d453b78cb5985ac6e5eb26",
-                describe="v5.16-rc4-31-g2a987e65025e"
-    )
+    revision_data = {
+        "tree": "mainline",
+        "url": "https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git",
+        "branch": "master",
+        "commit": "2a987e65025e2b79c6d453b78cb5985ac6e5eb26",
+        "describe": "v5.16-rc4-31-g2a987e65025e",
+    }
+
+    revision_obj = Revision.parse_obj(revision_data)
     node_obj = Node(
-            id="61bda8f2eb1a63d2b7152418",
-            kind="node",
-            name="checkout",
-            path=["checkout"],
-            group="debug",
-            revision=revision_obj,
-            parent=None,
-            state="closing",
-            result=None,
-        )
+        id="61bda8f2eb1a63d2b7152418",
+        kind="checkout",
+        name="checkout",
+        path=["checkout"],
+        group="debug",
+        data= {'kernel_revision': revision_obj},
+        parent=None,
+        state="closing",
+        result=None,
+    )
     mock_db_create.return_value = node_obj
 
     request_dict = {
         "name": "checkout",
+        "kind": "checkout",
         "path": ["checkout"],
-        "revision": {
-            "tree": "mainline",
-            "url": "https://git.kernel.org/pub/scm/linux/kernel/git/"
-                    "torvalds/linux.git",
-            "branch": "master",
-            "commit": "2a987e65025e2b79c6d453b78cb5985ac6e5eb26",
-            "describe": "v5.16-rc4-31-g2a987e65025e"
-        },
-        "data": {"foo": "bar"},
+        "data": {"kernel_revision": revision_data},
     }
     response = test_client.post(
         "node",
@@ -82,7 +76,6 @@ def test_create_node_endpoint(mock_db_create, mock_publish_cloudevent,
         'path',
         'parent',
         'result',
-        'revision',
         'state',
         'timeout',
         'updated',

--- a/tests/unit_tests/test_node_handler.py
+++ b/tests/unit_tests/test_node_handler.py
@@ -192,24 +192,23 @@ def test_get_node_by_id_endpoint(mock_db_find_by_id,
         JSON with Node object attributes
     """
     revision_obj = Revision(
-                tree="mainline",
-                url="https://git.kernel.org/pub/scm/linux/kernel/git/"
-                    "torvalds/linux.git",
-                branch="master",
-                commit="2a987e65025e2b79c6d453b78cb5985ac6e5eb26",
-                describe="v5.16-rc4-31-g2a987e65025e"
+        tree="mainline",
+        url="https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git",
+        branch="master",
+        commit="2a987e65025e2b79c6d453b78cb5985ac6e5eb26",
+        describe="v5.16-rc4-31-g2a987e65025e"
     )
     node_obj = Node(
-            id="61bda8f2eb1a63d2b7152418",
-            kind="node",
-            name="checkout",
-            path=["checkout"],
-            group="blah",
-            revision=revision_obj,
-            parent=None,
-            state="closing",
-            result=None,
-        )
+        id="61bda8f2eb1a63d2b7152418",
+        kind="checkout",
+        name="checkout",
+        path=["checkout"],
+        group="blah",
+        data = {'kernel_revision': revision_obj},
+        parent=None,
+        state="closing",
+        result=None,
+    )
     mock_db_find_by_id.return_value = node_obj
 
     response = test_client.get("node/61bda8f2eb1a63d2b7152418")
@@ -228,7 +227,6 @@ def test_get_node_by_id_endpoint(mock_db_find_by_id,
         'path',
         'parent',
         'result',
-        'revision',
         'state',
         'timeout',
         'updated',

--- a/tests/unit_tests/test_node_handler.py
+++ b/tests/unit_tests/test_node_handler.py
@@ -262,17 +262,18 @@ def test_get_all_nodes(mock_db_find_by_attributes,
     """
     node_obj_1 = {
         "id": "61bda8f2eb1a63d2b7152418",
-        "kind": "node",
+        "kind": "checkout",
         "name": "checkout",
         "path": ["checkout"],
-        "revision": {
-            "tree": "mainline",
-            "url": "https://git.kernel.org/pub/scm/linux/kernel/git/"
-                "torvalds/linux.git",
-            "branch": "master",
-            "commit": "2a987e65025e2b79c6d453b78cb5985ac6e5eb26",
-            "describe": "v5.16-rc4-31-g2a987e65025e",
-            "version": None,
+        "data": {
+            "kernel_revision": {
+                "tree": "mainline",
+                "url": "https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git",
+                "branch": "master",
+                "commit": "2a987e65025e2b79c6d453b78cb5985ac6e5eb26",
+                "describe": "v5.16-rc4-31-g2a987e65025e",
+                "version": None,
+            },
         },
         "parent": None,
         "state": "closing",
@@ -281,18 +282,19 @@ def test_get_all_nodes(mock_db_find_by_attributes,
 
     node_obj_2 = {
         "id": "61bda8f2eb1a63d2b7152414",
-        "kind": "node",
+        "kind": "checkout",
         "name": "test_node",
         "path": ["checkout", "test_suite", "test_node"],
         "group": None,
-        "revision": {
-            "tree": "mainline",
-            "url": "https://git.kernel.org/pub/scm/linux/kernel/git/"
-                   "torvalds/linux.git",
-            "branch": "master",
-            "commit": "2a987e65025e2b79c6d453b78cb5985ac6e5eb45",
-            "describe": "v5.16-rc4-31-g2a987e65025e",
-            "version": None,
+        "data": {
+            "kernel_revision": {
+                "tree": "mainline",
+                "url": "https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git",
+                "branch": "master",
+                "commit": "2a987e65025e2b79c6d453b78cb5985ac6e5eb45",
+                "describe": "v5.16-rc4-31-g2a987e65025e",
+                "version": None,
+            },
         },
         "parent": None,
         "state": "closing",
@@ -301,18 +303,19 @@ def test_get_all_nodes(mock_db_find_by_attributes,
 
     node_obj_3 = {
         "id": "61bda8f2eb1a63d2b7152421",
-        "kind": "node",
+        "kind": "checkout",
         "name": "test",
         "path": ["checkout", "group", "test"],
         "group": None,
-        "revision": {
-            "tree": "baseline",
-            "url": "https://git.kernel.org/pub/scm/linux/kernel/git/"
-                    "torvalds/linux.git",
-            "branch": "master",
-            "commit": "2a987e65025e2b79c6d453b78cb5985ac6e5eb26",
-            "describe": "v5.16-rc4-31-g2a987e65025e",
-            "version": None,
+        "data": {
+            "kernel_revision": {
+                "tree": "baseline",
+                "url": "https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git",
+                "branch": "master",
+                "commit": "2a987e65025e2b79c6d453b78cb5985ac6e5eb26",
+                "describe": "v5.16-rc4-31-g2a987e65025e",
+                "version": None,
+            },
         },
         "parent": None,
         "state": "closing",


### PR DESCRIPTION
**NOTE**: These changes _will_ break an API instance that is connected to a DB with existing nodes, since this changes the node models. The [db migration script](https://github.com/kernelci/kernelci-api/pull/395/commits/8792522463799f95554b793eb4f36bdeb3399b77) included in the changes handles the data migration cleanly (hopefully).

Related PRs:
- https://github.com/kernelci/kernelci-pipeline/pull/365
- https://github.com/kernelci/kernelci-core/pull/2224

https://github.com/kernelci/kernelci-core/pull/2224 and this PR are interdependent, so they should be merged together. I suggest https://github.com/kernelci/kernelci-core/pull/2224 is merged first, then this one and then https://github.com/kernelci/kernelci-pipeline/pull/365. Remember to apply the migration scripts.

This PR has already been tested with PR applied, with all tests passing. 

## Definition of Node and Node submodels

This is the main change of this PR. The initial requirements that lead to this are:

- We need objects to be properly defined and modeled, with pydantic offering automatic validation of their fields.
- We want to maintain the tree (or graph) structure of the nodes but adding specific object types depending on the entities they model.

These requirements fit well in an object oriented design where a base model (`Node`) provides the base graph structure as well as other metadata attributes (dates, ownership, etc.), and subclasses of this model provide the specific attributes that are relevant to each object type.

A way to implement this so that we can carry the object oriented nature throughout the application is to define all the subclass-specific attributes inside a "data" field, which will be a dict with arbitrary data from the point of view of the base class `Node` but will be defined with specific fields in each concrete subclass model.

In this scheme, `Node` is almost like an abstract class (we can create plain Nodes, but the contents of the `data` field won't be validated), and the submodels will be the concrete implementation subclasses that will be fully validated depending on their type, which is encoded in the `kind` field.

This way we can effectively implement dynamic polymorphism in data storage and retrieval. The lower layers (DB) aren't aware of different `Node` types, as they all share the same structure with the only differences being the contents of the "data" dict. All nodes are thus retrieved as plain `Node` objects, which are then interpreted and validated as concrete
types by the API.

## New models

### Checkout
The specific data of a checkout will be the `kernel_revision`.

### Kbuild
The specific data of a kernel build will be the `kernel_revision`, `arch`, `defconfig`, `compiler` and list of extra configuration `fragments`.

**NOTE**: if a kernel build node will always hang from a checkout node, then the kernel_revision can be retrieved from its parent node.

### Test
The specific data of a test will be the `kernel_revision` and the information about the test: source/repo and revision.

**NOTE**: if a test node will always hang from a kbuild node, then the kernel_revision can be retrieved from its parent node.

### Regression
The specific data of a regression will be the node that introduced the failure and the previous one that passed, ie. a regression is defined by a breaking point between nodes.

## Endpoint changes
The endpoints no longer map a node `kind` to a DB collection. All concrete `Node` objects are saved as `Node`s. The difference lies in the implementation of the operations that create nodes, which now perform object validation explicitly.

This means that we don't need a different endpoint for each node type. This leads to a simpler and cleaner implementation that takes advantage of the object-oriented design where possible. The drawback is that each node POST/PUT is now validated twice: one as a Node and other as a concrete `Node` subtype. I don't know if this could have a noticeable performance impact but, IMO, performance doesn't seem to be a critical key aspect of the system (we're using python for everything, after all), and the pros of this implementation far outweigh the cons.

The "regression" endpoints are removed since all Node subtypes can now work through the "node" endpoints.