### PR TITLE
doc: fix multiple config paths setting on Early Access page

### DIFF
--- a/doc/early-access.md
+++ b/doc/early-access.md
@@ -155,7 +155,7 @@ time.  For example:
 api = "early-access"
 storage = "early-access-azure-<your-username>"
 indent = 4
-config = ["config/core", "<your-username>.yaml"]
+config = ["/etc/kernelci/core", "<your-username>.yaml"]
 
 [kci.secrets]
 api.early-access.token = "<your-api-token-here>"


### PR DESCRIPTION
The config settings (--yaml-config) can take several values, but the first one should be the standard one in /etc/kernelci/core when adding a custom file on top of it.  Fix this instead of relying on a local config/core copy of the files.

Fixes: e8e94267a669 ("doc: update Early Access page with latest kci")