### PR TITLE
api.config: add module to define various settings (was #392)

### DIFF
--- a/api/auth.py
+++ b/api/auth.py
@@ -7,20 +7,12 @@
 """User authentication utilities"""
 
 from passlib.context import CryptContext
-from pydantic import BaseSettings
 from fastapi_users.authentication import (
     AuthenticationBackend,
     BearerTransport,
     JWTStrategy,
 )
-
-
-class Settings(BaseSettings):
-    """Authentication settings"""
-    secret_key: str
-    algorithm: str = "HS256"
-    # Set to None so tokens don't expire
-    access_token_expire_seconds: int = None
+from .config import AuthSettings
 
 
 class Authentication:
@@ -29,7 +21,7 @@ class Authentication:
     CRYPT_CTX = CryptContext(schemes=["bcrypt"], deprecated="auto")
 
     def __init__(self, token_url: str):
-        self._settings = Settings()
+        self._settings = AuthSettings()
         self._token_url = token_url
 
     @classmethod

--- a/api/config.py
+++ b/api/config.py
@@ -1,0 +1,32 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+#
+# Copyright (C) 2023 Collabora Limited
+# Author: Jeny Sadadia <jeny.sadadia@collabora.com>
+
+"""Module settings"""
+
+from pydantic import BaseSettings, EmailStr
+
+
+class AuthSettings(BaseSettings):
+    """Authentication settings"""
+    secret_key: str
+    algorithm: str = "HS256"
+    # Set to None so tokens don't expire
+    access_token_expire_seconds: float = None
+
+
+class PubSubSettings(BaseSettings):
+    """Pub/Sub settings loaded from the environment"""
+    cloud_events_source: str = "https://api.kernelci.org/"
+    redis_host: str = "redis"
+    redis_db_number: int = 1
+    keep_alive_period: int = 45
+
+
+class EmailSettings(BaseSettings):
+    """Email settings"""
+    smtp_host: str
+    smtp_port: int
+    email_sender: EmailStr
+    email_password: str

--- a/api/email_sender.py
+++ b/api/email_sender.py
@@ -11,21 +11,13 @@ from email.mime.multipart import MIMEMultipart
 import email
 import email.mime.text
 import smtplib
-from pydantic import BaseSettings, EmailStr
-
-
-class Settings(BaseSettings):
-    """Email settings"""
-    smtp_host: str
-    smtp_port: int
-    email_sender: EmailStr
-    email_password: str
+from .config import EmailSettings
 
 
 class EmailSender:
     """Class to send email report using SMTP"""
     def __init__(self):
-        self._settings = Settings()
+        self._settings = EmailSettings()
 
     def _smtp_connect(self):
         """Method to create a connection with SMTP server"""

--- a/api/pubsub.py
+++ b/api/pubsub.py
@@ -9,15 +9,8 @@ import asyncio
 
 import aioredis
 from cloudevents.http import CloudEvent, to_json
-from pydantic import BaseModel, BaseSettings, Field
-
-
-class Settings(BaseSettings):
-    """Pub/Sub settings loaded from the environment"""
-    cloud_events_source: str = "https://api.kernelci.org/"
-    redis_host: str = "redis"
-    redis_db_number: int = 1
-    keep_alive_period: int = 45
+from pydantic import BaseModel, Field
+from .config import PubSubSettings
 
 
 class Subscription(BaseModel):
@@ -49,7 +42,7 @@ class PubSub:
         return pubsub
 
     def __init__(self, host=None, db_number=None):
-        self._settings = Settings()
+        self._settings = PubSubSettings()
         if host is None:
             host = self._settings.redis_host
         if db_number is None:

--- a/api/user_manager.py
+++ b/api/user_manager.py
@@ -18,13 +18,13 @@ from fastapi_users.password import PasswordHelperProtocol
 from beanie import PydanticObjectId
 import jinja2
 from .user_models import User
-from .auth import Settings
+from .config import AuthSettings
 from .email_sender import EmailSender
 
 
 class UserManager(ObjectIDIDMixin, BaseUserManager[User, PydanticObjectId]):
     """User management logic"""
-    settings = Settings()
+    settings = AuthSettings()
     reset_password_token_secret = settings.secret_key
     verification_token_secret = settings.secret_key
 


### PR DESCRIPTION
Instead of defining multiple settings class in different API modules like `pubsub`, `auth`, `email_sender`, add `api.config` module to store all different settings classes.

Replaces #392 