### PR TITLE
docker/api: sort packages alphabetically in requirements.txt

### DIFF
--- a/docker/api/requirements.txt
+++ b/docker/api/requirements.txt
@@ -2,13 +2,13 @@ aioredis[hiredis]==2.0.0
 cloudevents==1.9.0
 fastapi[all]==0.68.1
 fastapi-pagination==0.9.3
+fastapi-users[beanie, oauth]==10.4.0
+fastapi-versioning==0.10.0
+MarkupSafe==2.0.1
+motor==2.5.1
 passlib==1.7.4
 pydantic==1.10.5
-python-jose[cryptography]==3.3.0
-uvicorn[standard]==0.13.4
-motor==2.5.1
 pymongo-migrate==0.11.0
+python-jose[cryptography]==3.3.0
 pyyaml==5.3.1
-fastapi-versioning==0.10.0
-fastapi-users[beanie, oauth]==10.4.0
-MarkupSafe==2.0.1
+uvicorn[standard]==0.13.4


### PR DESCRIPTION
Sort the list of packages alphabetically in requirements.txt to make it easier to maintain and avoid duplicates.