### PR TITLE
Fix several issues related to user management

### DIFF
--- a/api/main.py
+++ b/api/main.py
@@ -220,12 +220,13 @@ async def update_me(request: Request, user: UserUpdate,
     Custom user update router handler will only allow users to update
     its own profile. Adding itself to 'admin' group is not allowed.
     """
-    existing_user = await db.find_one(User, username=user.username)
-    if existing_user:
-        raise HTTPException(
-            status_code=status.HTTP_400_BAD_REQUEST,
-            detail="Username already exists",
-        )
+    if user.username and user.username != current_user.username:
+        existing_user = await db.find_one(User, username=user.username)
+        if existing_user:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail=f"Username already exists: {user.username}",
+            )
     groups = []
     if user.groups:
         for group_name in user.groups:
@@ -251,7 +252,6 @@ async def update_me(request: Request, user: UserUpdate,
 async def update_user(user_id: str, request: Request, user: UserUpdate,
                       current_user: User = Depends(get_current_superuser)):
     """Router to allow admin users to update other user account"""
-
     user_from_id = await db.find_by_id(User, user_id)
     if not user_from_id:
         raise HTTPException(
@@ -259,12 +259,13 @@ async def update_user(user_id: str, request: Request, user: UserUpdate,
             detail=f"User not found with id: {user_id}",
         )
 
-    existing_user = await db.find_one(User, username=user.username)
-    if existing_user:
-        raise HTTPException(
-            status_code=status.HTTP_400_BAD_REQUEST,
-            detail="Username already exists",
-        )
+    if user.username and user.username != user_from_id.username:
+        existing_user = await db.find_one(User, username=user.username)
+        if existing_user:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail=f"Username already exists: {user.username}",
+            )
 
     groups = []
     if user.groups:

--- a/api/main.py
+++ b/api/main.py
@@ -26,7 +26,6 @@ from fastapi_versioning import VersionedFastAPI
 from bson import ObjectId, errors
 from pymongo.errors import DuplicateKeyError
 from fastapi_users import FastAPIUsers
-from fastapi_users.db import BeanieUserDatabase
 from beanie import PydanticObjectId
 from .auth import Authentication
 from .db import Database
@@ -39,14 +38,13 @@ from .models import (
 )
 from .paginator_models import PageModel
 from .pubsub import PubSub, Subscription
-from .user_manager import get_user_manager
+from .user_manager import get_user_manager, create_user_manager
 from .user_models import (
     User,
     UserRead,
     UserCreate,
     UserUpdate,
 )
-from .user_manager import UserManager
 
 
 # List of all the supported API versions.  This is a placeholder until the API
@@ -64,6 +62,7 @@ fastapi_users_instance = FastAPIUsers[User, PydanticObjectId](
     get_user_manager,
     [auth_backend],
 )
+user_manager = create_user_manager()
 
 
 @app.on_event('startup')
@@ -167,7 +166,7 @@ async def register(request: Request, user: UserCreate,
             groups.append(group)
     user.groups = groups
     created_user = await register_router.routes[0].endpoint(
-        request, user, UserManager(BeanieUserDatabase(User)))
+        request, user, user_manager)
     # Update user to be an admin user explicitly if requested as
     # `fastapi-users` register route does not allow it
     if user.is_superuser:
@@ -244,7 +243,7 @@ async def update_me(request: Request, user: UserUpdate,
     if groups:
         user.groups = groups
     return await users_router.routes[1].endpoint(
-        request, user, current_user, UserManager(BeanieUserDatabase(User)))
+        request, user, current_user, user_manager)
 
 
 @app.patch("/user/{user_id}", response_model=UserRead, tags=["user"],
@@ -281,7 +280,8 @@ async def update_user(user_id: str, request: Request, user: UserUpdate,
         user.groups = groups
 
     updated_user = await users_router.routes[3].endpoint(
-        user, request, user_from_id, UserManager(BeanieUserDatabase(User)))
+        user, request, user_from_id, user_manager
+    )
     # Update user to be an admin user explicitly if requested as
     # `fastapi-users` user update route does not allow it
     if user.is_superuser:
@@ -334,8 +334,7 @@ async def update_password(request: Request,
                           credentials: OAuth2PasswordRequestForm = Depends(),
                           new_password: str = Form(None)):
     """Update user password"""
-    user = await UserManager(BeanieUserDatabase(User)).authenticate(
-        credentials)
+    user = await user_manager.authenticate(credentials)
     if user is None or not user.is_active:
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
@@ -344,8 +343,8 @@ async def update_password(request: Request,
     user_update = UserUpdate(password=new_password)
     user_from_username = await db.find_one(User, username=credentials.username)
     await users_router.routes[3].endpoint(
-        user_update, request, user_from_username,
-        UserManager(BeanieUserDatabase(User)))
+        user_update, request, user_from_username, user_manager
+    )
 
 
 # -----------------------------------------------------------------------------

--- a/api/user_manager.py
+++ b/api/user_manager.py
@@ -140,11 +140,16 @@ class UserManager(ObjectIDIDMixin, BaseUserManager[User, PydanticObjectId]):
         return user
 
 
+def create_user_manager():
+    """Create a UserManager object"""
+    return UserManager(BeanieUserDatabase(User))
+
+
 async def get_user_db():
-    """Database adapter for fastapi-users"""
+    """Get a generator with the database adapter for fastapi-users"""
     yield BeanieUserDatabase(User)
 
 
 async def get_user_manager(user_db: BeanieUserDatabase = Depends(get_user_db)):
-    """Get user manager"""
+    """Get a generator with the user manager"""
     yield UserManager(user_db)

--- a/api/user_manager.py
+++ b/api/user_manager.py
@@ -30,12 +30,19 @@ class UserManager(ObjectIDIDMixin, BaseUserManager[User, PydanticObjectId]):
 
     def __init__(self, user_db: BaseUserDatabase[User, PydanticObjectId],
                  password_helper: PasswordHelperProtocol | None = None):
-        self._email_sender = EmailSender()
+        self._email_sender = None
         self._template_env = jinja2.Environment(
                             loader=jinja2.FileSystemLoader(
                                 "./templates/")
                         )
         super().__init__(user_db, password_helper)
+
+    @property
+    def email_sender(self):
+        """EmailSender instance"""
+        if self._email_sender is None:
+            self._email_sender = EmailSender()
+        return self._email_sender
 
     async def on_after_register(self, user: User,
                                 request: Optional[Request] = None):
@@ -50,7 +57,7 @@ class UserManager(ObjectIDIDMixin, BaseUserManager[User, PydanticObjectId]):
         content = template.render(
             username=user.username, token=token
         )
-        self._email_sender.create_and_send_email(subject, content, user.email)
+        self.email_sender.create_and_send_email(subject, content, user.email)
 
     async def on_after_verify(self, user: User,
                               request: Optional[Request] = None):
@@ -62,7 +69,7 @@ class UserManager(ObjectIDIDMixin, BaseUserManager[User, PydanticObjectId]):
         content = template.render(
             username=user.username,
         )
-        self._email_sender.create_and_send_email(subject, content, user.email)
+        self.email_sender.create_and_send_email(subject, content, user.email)
 
     async def on_after_login(self, user: User,
                              request: Optional[Request] = None):
@@ -77,7 +84,7 @@ class UserManager(ObjectIDIDMixin, BaseUserManager[User, PydanticObjectId]):
         content = template.render(
             username=user.username, token=token
         )
-        self._email_sender.create_and_send_email(subject, content, user.email)
+        self.email_sender.create_and_send_email(subject, content, user.email)
 
     async def on_after_reset_password(self, user: User,
                                       request: Optional[Request] = None):
@@ -89,7 +96,7 @@ class UserManager(ObjectIDIDMixin, BaseUserManager[User, PydanticObjectId]):
         content = template.render(
             username=user.username,
         )
-        self._email_sender.create_and_send_email(subject, content, user.email)
+        self.email_sender.create_and_send_email(subject, content, user.email)
 
     async def on_after_update(self, user: User, update_dict: Dict[str, Any],
                               request: Optional[Request] = None):

--- a/api/user_manager.py
+++ b/api/user_manager.py
@@ -10,11 +10,9 @@ from fastapi import Depends, Request
 from fastapi.security import OAuth2PasswordRequestForm
 from fastapi_users import BaseUserManager
 from fastapi_users.db import (
-    BaseUserDatabase,
     BeanieUserDatabase,
     ObjectIDIDMixin,
 )
-from fastapi_users.password import PasswordHelperProtocol
 from beanie import PydanticObjectId
 import jinja2
 from .user_models import User
@@ -28,14 +26,12 @@ class UserManager(ObjectIDIDMixin, BaseUserManager[User, PydanticObjectId]):
     reset_password_token_secret = settings.secret_key
     verification_token_secret = settings.secret_key
 
-    def __init__(self, user_db: BaseUserDatabase[User, PydanticObjectId],
-                 password_helper: PasswordHelperProtocol | None = None):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
         self._email_sender = None
         self._template_env = jinja2.Environment(
-                            loader=jinja2.FileSystemLoader(
-                                "./templates/")
-                        )
-        super().__init__(user_db, password_helper)
+            loader=jinja2.FileSystemLoader("./templates/")
+        )
 
     @property
     def email_sender(self):


### PR DESCRIPTION
This PR fixes several issues found when testing the new user management implementation:

* `api.user_manager: call UserManager parent with all arguments`
  This is to avoid unexpected behaviour and fix hidden bugs.
* `api.main: rely on create_user_manager()`
  This is to have only one way of creating the UserManager objects and simplify the code
* `api.user_manager: create EmailSender only when required`
  This is to avoid requiring SMTP settings unless when actually trying to send an email
* `api.main: only look for duplicate user when required`
  This is to remove unwanted checks for duplicate users when no new username is being provided