### PR TITLE
api.admin: set is_verified=1 for the first superuser

### DIFF
--- a/api/admin.py
+++ b/api/admin.py
@@ -48,7 +48,8 @@ async def setup_admin_user(db, username, email, admin_group):
         hashed_password=hashed_password,
         email=email,
         groups=[admin_group],
-        is_superuser=1
+        is_superuser=1,
+        is_verified=1,
     ))
 
 


### PR DESCRIPTION
Bypass the email verification step when creating the first superuser as this is a special case.  Administrators should be able to create this entry entirely non-interactively, and they should also have direct access to the database anyway where this flag could be set by hand.