### PR TITLE
api.admin: fix `setup_admin_user`

### DIFF
--- a/api/admin.py
+++ b/api/admin.py
@@ -31,7 +31,7 @@ async def setup_admin_group(db, admin_group):
 
 async def setup_admin_user(db, username, email, admin_group):
     user_obj = await db.find_one_by_attributes(User,
-                                               {'profile.username': username})
+                                               {'username': username})
     if user_obj:
         print(f"User {username} already exists, aborting.")
         print(user_obj.json())

--- a/api/user_models.py
+++ b/api/user_models.py
@@ -35,6 +35,11 @@ class User(BeanieBaseUser, Document,  # pylint: disable=too-many-ancestors
         # MongoDB collection name for model
         name = "user"
 
+    @classmethod
+    def create_indexes(cls, collection):
+        """Create an index to bind unique constraint to email"""
+        collection.create_index("email", unique=True)
+
 
 class UserRead(schemas.BaseUser[PydanticObjectId], ModelId):
     """Schema for reading a user"""


### PR DESCRIPTION
Since `profile` field has been eliminated from `User` schema, update logic to check existing admin user by matching `username` field.

Fixes #401 