### PR TITLE
api.admin: fix method for setting node ownership

### DIFF
--- a/api/main.py
+++ b/api/main.py
@@ -556,7 +556,7 @@ async def put_node(node_id: str, node: Node,
 async def _set_node_ownership_recursively(user: User, hierarchy: Hierarchy):
     """Set node ownership information for a hierarchy of nodes"""
     if not hierarchy.node.owner:
-        hierarchy.node.owner = user.profile.username
+        hierarchy.node.owner = user.username
     for node in hierarchy.child_nodes:
         await _set_node_ownership_recursively(user, node)
 


### PR DESCRIPTION
Fix `_set_node_ownership_recursively` method to use `User.username` to get username as per the latest `User` schema while setting node ownership.