### PR TITLE
Enable support for unicast messages

### DIFF
--- a/api/main.py
+++ b/api/main.py
@@ -617,6 +617,21 @@ async def publish(raw: dict, channel: str,
     await pubsub.publish_cloudevent(channel, data, attributes)
 
 
+@app.post('/push/{list_name}')
+async def push(raw: dict, list_name: str,
+               user: User = Depends(get_current_user)):
+    """Push a message on the provided list"""
+    attributes = dict(raw)
+    data = attributes.pop('data')
+    await pubsub.push_cloudevent(list_name, data, attributes)
+
+
+@app.get('/pop/{list_name}')
+async def pop(list_name: str, user: User = Depends(get_current_user)):
+    """Pop a message from a given list"""
+    return await pubsub.pop(list_name)
+
+
 # -----------------------------------------------------------------------------
 # Regression
 

--- a/api/pubsub.py
+++ b/api/pubsub.py
@@ -7,7 +7,7 @@
 
 import asyncio
 
-import aioredis
+from redis import asyncio as aioredis
 from cloudevents.http import CloudEvent, to_json
 from pydantic import BaseModel, Field
 from .config import PubSubSettings

--- a/docker/api/requirements-tests.txt
+++ b/docker/api/requirements-tests.txt
@@ -1,5 +1,5 @@
 -r requirements.txt
-fakeredis==1.7.0
+fakeredis==2.20.0
 pytest==6.2.5
 pytest-asyncio==0.16.0
 pytest-dependency==0.5.1

--- a/docker/api/requirements.txt
+++ b/docker/api/requirements.txt
@@ -1,4 +1,3 @@
-aioredis[hiredis]==2.0.0
 cloudevents==1.9.0
 fastapi[all]==0.68.1
 fastapi-pagination==0.9.3
@@ -11,4 +10,5 @@ pydantic==1.10.5
 pymongo-migrate==0.11.0
 python-jose[cryptography]==3.3.0
 pyyaml==5.3.1
+redis==5.0.1
 uvicorn[standard]==0.13.4

--- a/tests/unit_tests/test_pubsub.py
+++ b/tests/unit_tests/test_pubsub.py
@@ -44,6 +44,8 @@ async def test_subscribe_multiple_channels(mock_pubsub):
         PubSub._subscriptions dict should have 2 entries. This entries'
         keys should be 1, 2, and 3.
     """
+    # Reset `ID_KEY` value to get subscription ID starting from 1
+    await mock_pubsub._redis.set(mock_pubsub.ID_KEY, 0)
     channels = ((1, 'CHANNEL1'), (2, 'CHANNEL2'), (3, 'CHANNEL3'))
     for expected_id, expected_channel in channels:
         result = await mock_pubsub.subscribe(expected_channel)


### PR DESCRIPTION
Use Redis list for enabling support for unicast messages for load-balancing use-case.
Introduced endpoints `/push` and `/pop` for pushing messages to a Redis list and popping a message from the
list respectively.