### PR TITLE
github/workflows: use hard-coded `SECRET_KEY` for tests

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -56,7 +56,7 @@ jobs:
 
       - name: Run pytest
         run: |
-          SECRET_KEY=$(openssl rand -hex 32) SMTP_HOST=smtp.gmail.com SMTP_PORT=465 EMAIL_SENDER=test@kernelci.org EMAIL_PASSWORD=random pytest -vs tests/unit_tests/
+          SECRET_KEY=b6451545d2e4635148d768f07877aade3ad8e7e160d52962badd7587a4b9a150 SMTP_HOST=smtp.gmail.com SMTP_PORT=465 EMAIL_SENDER=test@kernelci.org EMAIL_PASSWORD=random pytest -vs tests/unit_tests/
 
   lint:
     runs-on: ubuntu-22.04

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -29,7 +29,7 @@ jobs:
 
       - name: Export environment variables
         run: |
-          echo "SECRET_KEY=$(openssl rand -hex 32)" > .env
+          echo "SECRET_KEY=b6451545d2e4635148d768f07877aade3ad8e7e160d52962badd7587a4b9a150" > .env
           echo "SMTP_HOST=smtp.gmail.com" >> .env
           echo "SMTP_PORT=465" >> .env
           echo "EMAIL_SENDER=test@kernelci.org" >> .env


### PR DESCRIPTION
Fixes https://github.com/kernelci/kernelci-api/issues/402

Instead of generating `SECRET_KEY` value for every test run, use hard-coded value to reduce test failures and easy debugging for automated unit tests and e2e tests.