### PR TITLE
api.main: [trivial] handle runtime errors properly in listen endpoint

### DIFF
--- a/api/main.py
+++ b/api/main.py
@@ -606,6 +606,11 @@ async def listen(sub_id: int, user: User = Depends(get_current_user)):
             status_code=status.HTTP_404_NOT_FOUND,
             detail=f"Subscription id not found: {str(error)}"
         ) from error
+    except RuntimeError as error:
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail=f"Error while listening to sub id {sub_id}: {str(error)}"
+        ) from error
 
 
 @app.post('/publish/{channel}')


### PR DESCRIPTION
Certain scenarios may trigger a runtime error on the <listen> endpoint, particularly during development and testing. Handle them so the request returns an error message instead of crashing.