### PR TITLE
Implement endpoint to delete a user group

### DIFF
--- a/api/db.py
+++ b/api/db.py
@@ -194,3 +194,10 @@ class Database:
         if res.matched_count == 0:
             raise ValueError(f"No object found with id: {obj.id}")
         return obj.__class__(**await col.find_one(ObjectId(obj.id)))
+
+    async def delete_by_id(self, model, obj_id):
+        """Delete one object matching a given id"""
+        col = self._get_collection(model)
+        result = await col.delete_one({"_id": ObjectId(obj_id)})
+        if result.deleted_count == 0:
+            raise ValueError(f"No object found with id: {obj_id}")


### PR DESCRIPTION
implement DELETE `/group/<group-id>` endpoint to delete a user group.
Remove users from that group before deleting it. Also, check if the group is assigned to any node and remove it from user groups that are permitted to update the node.