### PR TITLE
Implement event ownership

### DIFF
--- a/api/main.py
+++ b/api/main.py
@@ -549,7 +549,10 @@ async def post_node(node: Node,
     node.owner = current_user.username
     obj = await db.create(node)
     data = _get_node_event_data('created', obj)
-    await pubsub.publish_cloudevent('node', data)
+    attributes = {}
+    if data.get('owner', None):
+        attributes['owner'] = data['owner']
+    await pubsub.publish_cloudevent('node', data, attributes)
     return obj
 
 
@@ -578,7 +581,10 @@ async def put_node(node_id: str, node: Node,
 
     obj = await db.update(node)
     data = _get_node_event_data('updated', obj)
-    await pubsub.publish_cloudevent('node', data)
+    attributes = {}
+    if data.get('owner', None):
+        attributes['owner'] = data['owner']
+    await pubsub.publish_cloudevent('node', data, attributes)
     return obj
 
 
@@ -600,7 +606,10 @@ async def put_nodes(
     await _set_node_ownership_recursively(user, nodes)
     obj_list = await db.create_hierarchy(nodes, Node)
     data = _get_node_event_data('updated', obj_list[0])
-    await pubsub.publish_cloudevent('node', data)
+    attributes = {}
+    if data.get('owner', None):
+        attributes['owner'] = data['owner']
+    await pubsub.publish_cloudevent('node', data, attributes)
     return obj_list
 
 

--- a/api/main.py
+++ b/api/main.py
@@ -643,7 +643,7 @@ async def unsubscribe(sub_id: int, user: User = Depends(get_current_user)):
 async def listen(sub_id: int, user: User = Depends(get_current_user)):
     """Listen messages from a subscribed Pub/Sub channel"""
     try:
-        return await pubsub.listen(sub_id)
+        return await pubsub.listen(sub_id, user.username)
     except KeyError as error:
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,

--- a/api/main.py
+++ b/api/main.py
@@ -610,7 +610,7 @@ async def put_nodes(
 @app.post('/subscribe/{channel}', response_model=Subscription)
 async def subscribe(channel: str, user: User = Depends(get_current_user)):
     """Subscribe handler for Pub/Sub channel"""
-    return await pubsub.subscribe(channel)
+    return await pubsub.subscribe(channel, user.username)
 
 
 @app.post('/unsubscribe/{sub_id}')

--- a/api/main.py
+++ b/api/main.py
@@ -626,11 +626,16 @@ async def subscribe(channel: str, user: User = Depends(get_current_user)):
 async def unsubscribe(sub_id: int, user: User = Depends(get_current_user)):
     """Unsubscribe handler for Pub/Sub channel"""
     try:
-        await pubsub.unsubscribe(sub_id)
+        await pubsub.unsubscribe(sub_id, user.username)
     except KeyError as error:
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,
             detail=f"Subscription id not found: {str(error)}"
+        ) from error
+    except RuntimeError as error:
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail=str(error)
         ) from error
 
 

--- a/api/main.py
+++ b/api/main.py
@@ -646,7 +646,20 @@ async def listen(sub_id: int, user: User = Depends(get_current_user)):
 async def publish(event: PublishEvent, channel: str,
                   user: User = Depends(get_current_user)):
     """Publish an event on the provided Pub/Sub channel"""
-    await pubsub.publish_cloudevent(channel, event.data, event.attributes)
+    event_dict = PublishEvent.dict(event)
+    # 1 - Extract data and attributes from the event
+    # 2 - Add the owner as an extra attribute
+    # 3 - Collect all the other extra attributes, if available, without
+    #     overwriting any of the standard ones in the dict
+    data = event_dict.pop('data')
+    extra_attributes = event_dict.pop("attributes")
+    attributes = event_dict
+    attributes['owner'] = user.username
+    if extra_attributes:
+        for k in extra_attributes:
+            if k not in attributes:
+                attributes[k] = extra_attributes[k]
+    await pubsub.publish_cloudevent(channel, data, attributes)
 
 
 @app.post('/push/{list_name}')

--- a/api/models.py
+++ b/api/models.py
@@ -369,22 +369,17 @@ def get_model_from_kind(kind: str):
     return models[kind]
 
 
-class PublishAttributes(BaseModel):
-    """API model for the attributes of a Publish operation"""
-    type: str = Field(
-        default='api.kernelci.org',
-        description="Type of the <publish> event"
-    )
-    source: str = Field(
-        description="Source of the <publish> event"
-    )
-
-
 class PublishEvent(BaseModel):
     """API model for the data of a <publish> event"""
-    attributes: Optional[PublishAttributes] = Field(
-        description="Event attributes"
-    )
-    data: Dict = Field(
+    data: Any = Field(
         description="Event payload"
+    )
+    type: Optional[str] = Field(
+        description="Type of the <publish> event"
+    )
+    source: Optional[str] = Field(
+        description="Source of the <publish> event"
+    )
+    attributes: Optional[Dict] = Field(
+        description="Extra Cloudevents Extension Context Attributes"
     )

--- a/api/pubsub.py
+++ b/api/pubsub.py
@@ -131,8 +131,12 @@ class PubSub:
             msg = await sub['redis_sub'].get_message(
                 ignore_subscribe_messages=True, timeout=1.0
             )
-            if msg is not None:
-                return msg
+            if msg is None:
+                continue
+            msg_data = json.loads(msg['data'])
+            if 'owner' in msg_data and msg_data['owner'] != sub['sub'].user:
+                continue
+            return msg
 
     async def publish(self, channel, message):
         """Publish a message on a channel

--- a/api/pubsub.py
+++ b/api/pubsub.py
@@ -170,10 +170,11 @@ class PubSub:
         for more details.
         """
         if not attributes:
-            attributes = {
-                "type": "api.kernelci.org",
-                "source": self._settings.cloud_events_source,
-            }
+            attributes = {}
+        if not attributes.get('type'):
+            attributes['type'] = "api.kernelci.org"
+        if not attributes.get('source'):
+            attributes['source'] = self._settings.cloud_events_source
         event = CloudEvent(attributes=attributes, data=data)
         await self.publish(channel, to_json(event))
 

--- a/api/pubsub.py
+++ b/api/pubsub.py
@@ -22,6 +22,10 @@ class Subscription(BaseModel):
     channel: str = Field(
         description='Subscription channel name'
     )
+    user: str = Field(
+        description=("Username of the user that created the "
+                     "subscription (owner)")
+    )
 
 
 class PubSub:

--- a/tests/e2e_tests/test_subscribe_handler.py
+++ b/tests/e2e_tests/test_subscribe_handler.py
@@ -28,7 +28,7 @@ def test_subscribe_node_channel(test_client):
     )
     pytest.node_channel_subscription_id = response.json()['id']
     assert response.status_code == 200
-    assert ('id', 'channel') == tuple(response.json().keys())
+    assert ('id', 'channel', 'user') == tuple(response.json().keys())
     assert response.json().get('channel') == 'node'
 
 
@@ -51,7 +51,7 @@ def test_subscribe_test_channel(test_client):
     )
     pytest.test_channel_subscription_id = response.json()['id']
     assert response.status_code == 200
-    assert ('id', 'channel') == tuple(response.json().keys())
+    assert ('id', 'channel', 'user') == tuple(response.json().keys())
     assert response.json().get('channel') == 'test_channel'
 
 
@@ -75,5 +75,5 @@ def test_subscribe_user_group_channel(test_client):
     )
     pytest.user_group_channel_subscription_id = response.json()['id']
     assert response.status_code == 200
-    assert ('id', 'channel') == tuple(response.json().keys())
+    assert ('id', 'channel', 'user') == tuple(response.json().keys())
     assert response.json().get('channel') == 'user_group'

--- a/tests/unit_tests/conftest.py
+++ b/tests/unit_tests/conftest.py
@@ -28,7 +28,7 @@ from api.main import (
 )
 from api.models import UserGroup
 from api.user_models import User
-from api.pubsub import PubSub
+from api.pubsub import PubSub, Subscription
 
 BEARER_TOKEN = "Bearer \
 eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJib2IifQ.\
@@ -223,8 +223,10 @@ def mock_pubsub_subscriptions(mocker):
     """Mocks `_redis` and `_subscriptions` member of PubSub class instance"""
     pubsub = PubSub()
     redis_mock = fakeredis.aioredis.FakeRedis()
+    sub = Subscription(id=1, channel='test', user='test')
     mocker.patch.object(pubsub, '_redis', redis_mock)
-    subscriptions_mock = dict({1: pubsub._redis.pubsub()})
+    subscriptions_mock = dict(
+        {1: {'sub': sub, 'redis_sub': pubsub._redis.pubsub()}})
     mocker.patch.object(pubsub, '_subscriptions', subscriptions_mock)
     return pubsub
 

--- a/tests/unit_tests/test_pubsub.py
+++ b/tests/unit_tests/test_pubsub.py
@@ -23,7 +23,7 @@ async def test_subscribe_single_channel(mock_pubsub):
         PubSub._subscriptions dict should have one entry. This entry's
         key should be equal 1.
     """
-    result = await mock_pubsub.subscribe('CHANNEL')
+    result = await mock_pubsub.subscribe('CHANNEL', 'test')
     assert result.channel == 'CHANNEL'
     assert result.id == 1
     assert len(mock_pubsub._subscriptions) == 1
@@ -48,7 +48,7 @@ async def test_subscribe_multiple_channels(mock_pubsub):
     await mock_pubsub._redis.set(mock_pubsub.ID_KEY, 0)
     channels = ((1, 'CHANNEL1'), (2, 'CHANNEL2'), (3, 'CHANNEL3'))
     for expected_id, expected_channel in channels:
-        result = await mock_pubsub.subscribe(expected_channel)
+        result = await mock_pubsub.subscribe(expected_channel, 'test')
         assert result.channel == expected_channel
         assert result.id == expected_id
     assert len(mock_pubsub._subscriptions) == 3

--- a/tests/unit_tests/test_subscribe_handler.py
+++ b/tests/unit_tests/test_subscribe_handler.py
@@ -18,7 +18,7 @@ def test_subscribe_endpoint(mock_subscribe, test_client):
         HTTP Response Code 200 OK
         JSON with 'id' and 'channel' keys
     """
-    subscribe = Subscription(id=1, channel='abc')
+    subscribe = Subscription(id=1, channel='abc', user='test')
     mock_subscribe.return_value = subscribe
 
     response = test_client.post(
@@ -29,4 +29,4 @@ def test_subscribe_endpoint(mock_subscribe, test_client):
     )
     print("response.json()", response.json())
     assert response.status_code == 200
-    assert ('id', 'channel') == tuple(response.json().keys())
+    assert ('id', 'channel', 'user') == tuple(response.json().keys())


### PR DESCRIPTION
## Introduction

This PR features a first basic step towards proper event filtering and handling. User ownership data is added to events and subscriptions, and the ownership is checked by default in "listen" and "unsubscribe" operations.

## Functional changes

### Changes to PublishEvent and Subscription

The `Subscription` model now includes a `user` field to store the username associated to the subscription (ie. the "owner"). **NOTE: This assumes that usernames are unique.**

The `PublishEvent` model was simplified and the processing of events through the `publish` endpoint now includes an implicit definition of the event owner and it allows overriding the default "type" and "source" attributes (if that's ever needed, if not we can remove this) and adding other extra attributes freely. From a users perspective, the only mandatory field in the request is `data` (dict). Any other extra attributes can be defined in `attributes` (dict).

Example payload for a `publish` request with a custom extra attribute: `'{"data" : {"my_event_id" : 1}, "attributes" : {"level" : "critical"}}'`. The owner attribute is added automatically by the server.

### Listening for events now receives only those published by the same user and "anonymous" events

By default, a request to the `listen` endpoint will only receive events owned by the same user that's listening. Anonymous events (ie. events that don't define an `owner`, such as keepalive events) are still received by all subscribers.
(See "Disabling user-checking on event listening" below for alternatives).

### Users can unsubscribe their own subscriptions only

Check user ownership of subscriptions to prevent a user from removing a subscription that another user created.

### Ownership of node creation events

All node creation events published by the `node` and `nodes` endpoints now have the authenticated request user as the owner, so only this user will receive these events.

## Open questions

### Better integration of the User handling functionalities into this

This PR is very basic and it doesn't make full use of the user management capabilities that are currently implemented. We may want to make a better use of these capabilities, for example, to do permission and ownership checks based on user groups.

### Disabling user-checking on event listening

Even if we want to keep and check the ownership of a subscription (to let only the owner unsubscribe, for instance), there'll probably be use cases where a privileged user might want to implement a monitor or a debugger that can listen to any arbitrary event regardless of its owner. This can be implemented by using an additional Subscription attribute to define its type ("regular-user subscription", "monitor-mode subscription", etc)

### Features based on user capabilities

Certain (future) features could be made available only to certain users or user groups, such as admins.

### Server-side event filtering

Currently, events are filtered in the client side by helper functions. The same thing can be done in the server side, moving the processing to the server and hiding unwanted data from ever reaching the clients. Would this be useful or desirable?