### PR TITLE
api.main: fix HTTP middleware

### DIFF
--- a/api/main.py
+++ b/api/main.py
@@ -677,7 +677,7 @@ for sub_app in versioned_app.routes:
         )
 
 
-@app.middleware("http")
+@versioned_app.middleware("http")
 async def redirect_http_requests(request: Request, call_next):
     """Redirect request with version prefix when no version is provided"""
     response = None


### PR DESCRIPTION
HTTP middleware is not redirecting requests when received with no version prefix. Fix it by using versioned API instance instead of `FastAPI` instance.

Fixes: 8e23ec5 ("api.main: rename versioned app instance")