### PR TITLE
Move `Subscription` model definition 

### DIFF
--- a/api/main.py
+++ b/api/main.py
@@ -35,10 +35,11 @@ from .models import (
     Regression,
     UserGroup,
     PublishEvent,
+    Subscription,
     get_model_from_kind
 )
 from .paginator_models import PageModel
-from .pubsub import PubSub, Subscription
+from .pubsub import PubSub
 from .user_manager import get_user_manager, create_user_manager
 from .user_models import (
     User,

--- a/api/models.py
+++ b/api/models.py
@@ -383,3 +383,17 @@ class PublishEvent(BaseModel):
     attributes: Optional[Dict] = Field(
         description="Extra Cloudevents Extension Context Attributes"
     )
+
+
+class Subscription(BaseModel):
+    """Pub/Sub subscription object model"""
+    id: int = Field(
+        description='Subscription ID'
+    )
+    channel: str = Field(
+        description='Subscription channel name'
+    )
+    user: str = Field(
+        description=("Username of the user that created the "
+                     "subscription (owner)")
+    )

--- a/api/pubsub.py
+++ b/api/pubsub.py
@@ -10,22 +10,8 @@ import asyncio
 import json
 from redis import asyncio as aioredis
 from cloudevents.http import CloudEvent, to_json
-from pydantic import BaseModel, Field
 from .config import PubSubSettings
-
-
-class Subscription(BaseModel):
-    """Pub/Sub subscription object model"""
-    id: int = Field(
-        description='Subscription ID'
-    )
-    channel: str = Field(
-        description='Subscription channel name'
-    )
-    user: str = Field(
-        description=("Username of the user that created the "
-                     "subscription (owner)")
-    )
+from .models import Subscription
 
 
 class PubSub:

--- a/tests/unit_tests/conftest.py
+++ b/tests/unit_tests/conftest.py
@@ -26,9 +26,9 @@ from api.main import (
     get_current_user,
     get_current_superuser,
 )
-from api.models import UserGroup
+from api.models import UserGroup, Subscription
 from api.user_models import User
-from api.pubsub import PubSub, Subscription
+from api.pubsub import PubSub
 
 BEARER_TOKEN = "Bearer \
 eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJib2IifQ.\

--- a/tests/unit_tests/test_subscribe_handler.py
+++ b/tests/unit_tests/test_subscribe_handler.py
@@ -8,7 +8,7 @@
 """Unit test function for KernelCI API subscribe handler"""
 
 from tests.unit_tests.conftest import BEARER_TOKEN
-from api.pubsub import Subscription
+from api.models import Subscription
 
 
 def test_subscribe_endpoint(mock_subscribe, test_client):


### PR DESCRIPTION
Move `Subscription` model definition to module containing all the generic API models i.e. `api/models.py` to keep coding style consistent.
Update unit tests accordingly.