### PR TITLE
api/main.py: Add permissive CORS policy

### DIFF
--- a/api/main.py
+++ b/api/main.py
@@ -19,6 +19,7 @@ from fastapi import (
     Request,
     Form
 )
+from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import JSONResponse, PlainTextResponse
 from fastapi.security import OAuth2PasswordRequestForm
 from fastapi_pagination import add_pagination
@@ -704,6 +705,13 @@ versioned_app = VersionedFastAPI(
         ]
     )
 
+versioned_app.add_middleware(
+    CORSMiddleware,
+    allow_origins=["*"],
+    allow_credentials=True,
+    allow_methods=["*"],
+    allow_headers=["*"],
+)
 
 """Workaround to use global exception handlers for versioned API.
 The issue has already been reported here:

--- a/api/main.py
+++ b/api/main.py
@@ -713,10 +713,10 @@ versioned_app.add_middleware(
     allow_headers=["*"],
 )
 
-"""Workaround to use global exception handlers for versioned API.
-The issue has already been reported here:
-https://github.com/DeanWay/fastapi-versioning/issues/30
-"""
+
+# Workaround to use global exception handlers for versioned API.
+# The issue has already been reported here:
+# https://github.com/DeanWay/fastapi-versioning/issues/30
 for sub_app in versioned_app.routes:
     if hasattr(sub_app.app, "add_exception_handler"):
         sub_app.app.add_exception_handler(


### PR DESCRIPTION
As we might experiment with 3rd party web applications we need CORS policy to be defined.
Probably it need to be more strict in the future.