### PR TITLE
Remove `admin` user group

### DIFF
--- a/api/main.py
+++ b/api/main.py
@@ -220,7 +220,7 @@ async def update_me(request: Request, user: UserUpdate,
     """User update route
 
     Custom user update router handler will only allow users to update
-    its own profile. Adding itself to 'admin' group is not allowed.
+    its own profile.
     """
     if user.username and user.username != current_user.username:
         existing_user = await db.find_one(User, username=user.username)
@@ -232,10 +232,6 @@ async def update_me(request: Request, user: UserUpdate,
     groups = []
     if user.groups:
         for group_name in user.groups:
-            if group_name == "admin":
-                raise HTTPException(
-                    status_code=status.HTTP_400_BAD_REQUEST,
-                    detail="Unauthorized to add user to 'admin' group")
             group = await db.find_one(UserGroup, name=group_name)
             if not group:
                 raise HTTPException(

--- a/tests/e2e_tests/test_pipeline.py
+++ b/tests/e2e_tests/test_pipeline.py
@@ -17,7 +17,7 @@ from .test_node_handler import create_node, get_node_by_id, update_node
     depends=[
         'e2e_tests/test_subscribe_handler.py::test_subscribe_node_channel'],
     scope='session')
-@pytest.mark.order(5)
+@pytest.mark.order(4)
 @pytest.mark.asyncio
 async def test_node_pipeline(test_async_client):
     """

--- a/tests/e2e_tests/test_subscribe_handler.py
+++ b/tests/e2e_tests/test_subscribe_handler.py
@@ -12,7 +12,7 @@ import pytest
 @pytest.mark.dependency(
     depends=['e2e_tests/test_user_creation.py::test_create_regular_user'],
     scope='session')
-@pytest.mark.order(4)
+@pytest.mark.order(3)
 def test_subscribe_node_channel(test_client):
     """
     Test Case : Test KernelCI API '/subscribe' endpoint with 'node' channel
@@ -35,7 +35,7 @@ def test_subscribe_node_channel(test_client):
 @pytest.mark.dependency(
     depends=['e2e_tests/test_user_creation.py::test_create_regular_user'],
     scope='session')
-@pytest.mark.order(4)
+@pytest.mark.order(3)
 def test_subscribe_test_channel(test_client):
     """
     Test Case : Test KernelCI API '/subscribe' endpoint with 'test_channel'
@@ -58,7 +58,7 @@ def test_subscribe_test_channel(test_client):
 @pytest.mark.dependency(
     depends=['e2e_tests/test_user_creation.py::test_create_regular_user'],
     scope='session')
-@pytest.mark.order(4)
+@pytest.mark.order(3)
 def test_subscribe_user_group_channel(test_client):
     """
     Test Case : Test KernelCI API '/subscribe' endpoint with 'user_group'

--- a/tests/e2e_tests/test_user_creation.py
+++ b/tests/e2e_tests/test_user_creation.py
@@ -9,7 +9,6 @@ import json
 import pytest
 
 from e2e_tests.conftest import db_create
-from api.models import UserGroup
 from api.user_models import User
 from api.db import Database
 from api.auth import Authentication
@@ -19,7 +18,7 @@ from api.auth import Authentication
     depends=["e2e_tests/test_user_group_handler.py::test_create_user_groups"],
     scope="session")
 @pytest.mark.dependency()
-@pytest.mark.order(2)
+@pytest.mark.order(1)
 @pytest.mark.asyncio
 async def test_create_admin_user(test_async_client):
     """
@@ -38,7 +37,7 @@ async def test_create_admin_user(test_async_client):
             username=username,
             hashed_password=hashed_password,
             email='test-admin@kernelci.org',
-            groups=[UserGroup(name="admin")],
+            groups=[],
             is_superuser=1,
             is_verified=1
         ))
@@ -62,7 +61,7 @@ async def test_create_admin_user(test_async_client):
 
 
 @pytest.mark.dependency(depends=["test_create_admin_user"])
-@pytest.mark.order(3)
+@pytest.mark.order(2)
 @pytest.mark.asyncio
 async def test_create_regular_user(test_async_client):
     """

--- a/tests/e2e_tests/test_user_group_handler.py
+++ b/tests/e2e_tests/test_user_group_handler.py
@@ -9,50 +9,7 @@ import pytest
 from cloudevents.http import from_json
 import json
 
-from api.models import UserGroup
-from api.db import Database
-from e2e_tests.conftest import db_create
 from .listen_handler import create_listen_task
-
-
-@pytest.mark.dependency()
-@pytest.mark.order(1)
-@pytest.mark.asyncio
-async def test_create_user_groups():
-    """
-    Test Case : Create default user groups
-    """
-    default_user_groups = ['admin']
-    for group in default_user_groups:
-        obj = await db_create(
-            Database.COLLECTIONS[UserGroup],
-            UserGroup(name=group))
-        assert obj is not None
-
-
-@pytest.mark.dependency(
-    depends=["test_create_user_groups"])
-@pytest.mark.asyncio
-async def test_get_user_group(test_async_client):
-    """
-    Test Case : Get user groups
-    Expected Result :
-        HTTP Response Code 200 OK
-        Returns dictionary with UserGroup objects, total number of groups
-        returned along with limit and offset values
-    """
-    response = await test_async_client.get(
-        "groups",
-    )
-    assert response.status_code == 200
-    assert response.json().keys() == {
-            'items',
-            'total',
-            'limit',
-            'offset',
-        }
-    assert response.json()['total'] == 1
-    assert response.json()['items'][0]['name'] == 'admin'
 
 
 @pytest.mark.dependency(

--- a/tests/unit_tests/conftest.py
+++ b/tests/unit_tests/conftest.py
@@ -26,7 +26,6 @@ from api.main import (
     get_current_user,
     get_current_superuser,
 )
-from api.models import UserGroup
 from api.user_models import User
 from api.pubsub import PubSub, Subscription
 
@@ -86,7 +85,7 @@ def mock_get_current_admin_user(request: Request):
         hashed_password='$2b$12$CpJZx5ooxM11bCFXT76/z.o6HWs2sPJy4iP8.'
                         'xCZGmM8jWXUXJZ4K',
         email='admin@kernelci.org',
-        groups=[UserGroup(name='admin')],
+        groups=[],
         is_active=True,
         is_superuser=True,
         is_verified=True

--- a/tests/unit_tests/test_user_handler.py
+++ b/tests/unit_tests/test_user_handler.py
@@ -74,7 +74,7 @@ async def test_create_admin_user(test_async_client, mock_db_find_one,
         id='61bda8f2eb1a63d2b7152419',
         username='test_admin',
         email='test-admin@kernelci.org',
-        groups=[UserGroup(name='admin')],
+        groups=[],
         is_active=True,
         is_verified=False,
         is_superuser=True


### PR DESCRIPTION
With `fastapi-users` integration, `User.is_superuser` flag has been introduced to identify admin users. 
This eliminates the requirement for creating any specific user group for admin users. Hence, discard the method to setup `admin` user group from the script.