### PR TITLE
kube/minikube: add email configuration variables

### DIFF
--- a/kube/minikube/api-deployment.yaml
+++ b/kube/minikube/api-deployment.yaml
@@ -38,6 +38,26 @@ spec:
               configMapKeyRef:
                 name: kernelci-api-config
                 key: mongo_service
+          - name: EMAIL_SENDER
+              valueFrom:
+                configMapKeyRef:
+                  name: kernelci-api-config
+                  key: email_sender
+          - name: EMAIL_PASSWORD
+            valueFrom:
+              secretKeyRef:
+                name: kernelci-api-secret
+                key: email-password
+          - name: SMTP_HOST
+            valueFrom:
+              configMapKeyRef:
+                name: kernelci-api-config
+                key: smtp_host
+          - name: SMTP_PORT
+            valueFrom:
+              configMapKeyRef:
+                name: kernelci-api-config
+                key: smtp_port
         volumeMounts:
           - name: api-volume
             mountPath: /home/kernelci/api

--- a/kube/minikube/configmap/api-configmap.yaml
+++ b/kube/minikube/configmap/api-configmap.yaml
@@ -11,3 +11,6 @@ metadata:
 data:
   redis_host: "kernelci-api-redis.default.svc.cluster.local"
   mongo_service: "mongodb://kernelci-api-db.default.svc.cluster.local:27017"
+  email_sender: "sample@kernelci.org"
+  smtp_host: "smtp.gmail.com"
+  smtp_port: "465"


### PR DESCRIPTION
Define `ConfigMap` variables for email-related configurations. Update `api` deployment file to use newly added configurations.