### PR TITLE
api.db: decouple model indexes from DB engine

### DIFF
--- a/api/db.py
+++ b/api/db.py
@@ -62,8 +62,12 @@ class Database:
     async def create_indexes(self):
         """Create indexes for models"""
         for model in self.COLLECTIONS:
+            indexes = model.get_indexes()
+            if not indexes:
+                continue
             col = self._get_collection(model)
-            model.create_indexes(col)
+            for index in indexes:
+                col.create_index(index.field, **index.attributes)
 
     async def find_one(self, model, **kwargs):
         """Find one object with matching attributes

--- a/api/models.py
+++ b/api/models.py
@@ -66,9 +66,11 @@ class UserGroup(DatabaseModel):
     )
 
     @classmethod
-    def create_indexes(cls, collection):
-        """Create an index to bind unique constraint to group name"""
-        collection.create_index("name", unique=True)
+    def get_indexes(cls):
+        """Get an index to bind unique constraint to group name"""
+        return [
+            cls.Index('name', {'unique': True}),
+        ]
 
 
 class User(BeanieBaseUser, Document,  # pylint: disable=too-many-ancestors
@@ -86,9 +88,11 @@ class User(BeanieBaseUser, Document,  # pylint: disable=too-many-ancestors
         name = "user"
 
     @classmethod
-    def create_indexes(cls, collection):
-        """Create an index to bind unique constraint to email"""
-        collection.create_index("email", unique=True)
+    def get_indexes(cls):
+        """Get indices"""
+        return [
+            cls.Index('email', {'unique': True}),
+        ]
 
 
 class UserRead(schemas.BaseUser[PydanticObjectId], ModelId):


### PR DESCRIPTION
Depends on https://github.com/kernelci/kernelci-core/pull/2399
Closes https://github.com/kernelci/kernelci-api/issues/437

Implement a dataclass `Index` to store model field names and constraints to create indexes. Instead of directly creating indexes from model method for specific DB engine (at the moment, MongoDB), implement a method to get indexes from models independent of DB engine i.e. list of
`DatabaseModel.Index` class instances. Create MongoDB specific indexes in the database method `Database.create_indexes`.