### PR TITLE
Assorted e2e test updates

### DIFF
--- a/run_e2e_tests.sh
+++ b/run_e2e_tests.sh
@@ -9,5 +9,5 @@
 
 docker-compose -f test-docker-compose.yaml build
 docker-compose -f test-docker-compose.yaml up -d api db redis storage ssh test
-docker-compose -f test-docker-compose.yaml exec test pytest -v tests/e2e_tests
+docker-compose -f test-docker-compose.yaml exec test pytest -v e2e_tests
 docker-compose -f test-docker-compose.yaml down

--- a/run_e2e_tests.sh
+++ b/run_e2e_tests.sh
@@ -8,6 +8,6 @@
 # Script for running API end-to-end tests
 
 docker-compose -f test-docker-compose.yaml build
-docker-compose -f test-docker-compose.yaml up -d api db redis storage ssh
-docker-compose -f test-docker-compose.yaml up test
+docker-compose -f test-docker-compose.yaml up -d api db redis storage ssh test
+docker-compose -f test-docker-compose.yaml exec test pytest -v tests/e2e_tests
 docker-compose -f test-docker-compose.yaml down

--- a/test-docker-compose.yaml
+++ b/test-docker-compose.yaml
@@ -56,6 +56,7 @@ services:
     volumes:
       - './api:/home/kernelci/api'
       - './tests:/home/kernelci/tests'
+      - './tests/e2e_tests:/home/kernelci/e2e_tests'
     depends_on:
       - api
     env_file:

--- a/tests/e2e_tests/test_pipeline.py
+++ b/tests/e2e_tests/test_pipeline.py
@@ -44,13 +44,15 @@ async def test_node_pipeline(test_async_client):
     node = {
         "name": "checkout",
         "path": ["checkout"],
-        "revision": {
-            "tree": "mainline",
-            "url": "https://git.kernel.org/pub/scm/linux/kernel/git/"
-                    "torvalds/linux.git",
-            "branch": "master",
-            "commit": "2a987e65025e2b79c6d453b78cb5985ac6e5eb28",
-            "describe": "v5.16-rc4-31-g2a987e65025e"
+        "data": {
+            "kernel_revision": {
+                "tree": "mainline",
+                "url": ("https://git.kernel.org/pub/scm/linux/kernel/git/"
+                       "torvalds/linux.git"),
+                "branch": "master",
+                "commit": "2a987e65025e2b79c6d453b78cb5985ac6e5eb28",
+                "describe": "v5.16-rc4-31-g2a987e65025e"
+            }
         }
     }
     response = await create_node(test_async_client, node)


### PR DESCRIPTION
- Fix pipeline test (sync it to Node model changes)
- The "test" service of test-docker-compose.yaml no longer launches the tests on startup. Update the run_e2e_tests.sh script to start the service and run the tests.
- Fix inconsistencies in pytest dependencies