### PR TITLE
README: fix links

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Please refer to the [architecture](https://kernelci.org/docs/api/overview/#api-a
 
 ## Getting started with docker-compose
 
-Please refer to [start Docker containers](https://kernelci.org/docs/api/getting-started/#start-docker-compose) of all the services.
+Please refer to [start Docker containers](https://kernelci.org/docs/api/local-instance/#start-docker-compose) of all the services.
 
 Note that the FastAPI server is running on port 8000 inside the container, but
 it's exposed to the host via port 8001 to avoid conflicts with other services.
@@ -26,10 +26,10 @@ This can be adjusted for each setup in
 
 ## Authentication
 
-Generate a new key for [Authentication](https://kernelci.org/docs/api/getting-started/#create-the-environment-file
+Generate a new key for [Authentication](https://kernelci.org/docs/api/local-instance/#create-the-environment-file)
 ).
-After that, please refer to [create and add a user](https://kernelci.org/docs/api/getting-started/#create-a-user-account) in Mongo DB.
-The user can also generate an [API token](https://kernelci.org/docs/api/getting-started/#create-an-api-token) to use API endpoints.
+After that, please refer to [create and add a user](https://kernelci.org/docs/api/local-instance/#create-an-admin-user-account) in Mongo DB.
+The user can also generate an [API token](https://kernelci.org/docs/api/local-instance/#create-an-admin-api-token) to use API endpoints.
 
 Ultimately, there will be a web frontend to provide a login form.  We don't
 have that yet as this new KernelCI API implementation is still in its early
@@ -59,7 +59,7 @@ Install Python requirements with additional packages for testing:
 pip install -r docker/api/requirements-dev.txt
 ```
 
-We have already created .env file from [Authentication](https://github.com/kernelci/kernelci-api#authentication) section.
+We have already created .env file from [Authentication](#authentication) section.
 Export the file with SECRET_KEY environment variable in it:
 ```
 export $(cat .env)


### PR DESCRIPTION
The "Getting Started" page has been replaced with "Local Instance", so update all the corresponding links. While at it, add minor updates:
* properly terminate a link entry
* drop the full URL from the internal "Authentication" link so it always point to the current document (avoid potential future breakages)