### PR TITLE
doc/early-access: use correct argument for email verification

### DIFF
--- a/doc/early-access.md
+++ b/doc/early-access.md
@@ -89,7 +89,7 @@ Retype new password:
 sent to your email:
 
 ```sh
-$ kci user verify <your-username>
+$ kci user verify <your-email>
 Sending verification token to <your-email>
 Verification token: <verification-token>
 Email verification successful!


### PR DESCRIPTION
Tool "kci" expects email as an argument (not the user name):

```
$ ./kci user verify --help

Usage: kci user verify [OPTIONS] EMAIL

(snip)
```