### PR TITLE
api.db: add support for regexes in mongodb queries

### DIFF
--- a/api/db.py
+++ b/api/db.py
@@ -34,6 +34,7 @@ class Database:
         'gt': '$gt',
         'gte': '$gte',
         'ne': '$ne',
+        're': '$regex',
     }
 
     BOOL_VALUE_MAP = {


### PR DESCRIPTION
Introduce a new API query operator (re) to match query parameters using mongodb-compatible regular expressions.

Mongodb has built-in regex capabilities for queries, so we get those for free if we simply add support for an additional query operator.