### PR TITLE
pyproject.toml: add missing modules to project deps

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,8 @@
 # SPDX-License-Identifier: LGPL-2.1-or-later
 #
-# Copyright (C) 2023 Collabora Limited
+# Copyright (C) 2023, 2024 Collabora Limited
 # Author: Guillaume Tucker <guillaume.tucker@collabora.com>
+# Author: Jeny Sadadia <jeny.sadadia@collabora.com>
 
 [project]
 name = "kernelci-api"
@@ -11,18 +12,37 @@ readme = "README.md"
 requires-python = ">=3.10"
 license = {text = "LGPL-2.1-or-later"}
 dependencies = [
-  "aioredis[hiredis] == 2.0.0",
   "cloudevents == 1.9.0",
   "fastapi[all] == 0.68.1",
   "fastapi-pagination == 0.9.3",
+  "fastapi-users[beanie, oauth] == 10.4.0",
+  "fastapi-versioning == 0.10.0",
+  "MarkupSafe == 2.0.1",
+  "motor == 2.5.1",
   "passlib == 1.7.4",
   "pydantic == 1.10.5",
-  "python-jose[cryptography] == 3.3.0",
-  "uvicorn[standard] == 0.13.4",
-  "motor == 2.5.1",
   "pymongo-migrate == 0.11.0",
+  "python-jose[cryptography] == 3.3.0",
   "pyyaml == 5.3.1",
-  "fastapi-versioning == 0.10.0",
+  "redis == 5.0.1",
+  "uvicorn[standard] == 0.13.4",
+]
+
+[project.optional-dependencies]
+tests = [
+  "fakeredis == 2.20.0",
+  "pytest == 6.2.5",
+  "pytest-asyncio == 0.16.0",
+  "pytest-dependency == 0.5.1",
+  "pytest-mock == 3.6.1",
+  "pytest-order == 1.0.1",
+  "httpx == 0.23.3",
+  "mongomock_motor == 0.0.21",
+]
+dev = [
+  "kernelci-api[tests]",
+  "pycodestyle == 2.8.0",
+  "pylint == 2.12.2",
 ]
 
 [project.urls]


### PR DESCRIPTION
Fixes https://github.com/kernelci/kernelci-api/issues/469

New python packages were added to `requirements.txt` after `fastapi-users` integration.
Add all those packages to `pyproject.toml`. Also, re-order the existing packages to maintain package version dependencies.
Added a section for optional dependencies as well. The package can be installed with the below commands
including optional dependencies:
To run API tests: `python3 -m pip install .[tests]` 
For developer mode: `python3 -m pip install .[dev]`