### PR TITLE
api.main: preserve model parsing and fix `kver` job

### DIFF
--- a/api/main.py
+++ b/api/main.py
@@ -540,7 +540,11 @@ async def post_node(node: Node,
                     current_user: User = Depends(get_current_user)):
     """Create a new node"""
     # Explicit pydantic model validation
-    parse_node_obj(node)
+    parsed_node = parse_node_obj(node)
+    # Convert again to parent model `Node` in order to enable JSON
+    # serialization of nested models (such as `CheckoutData`) and
+    # map model against existing DB collection i.e. `Node`
+    node = Node(**parsed_node.dict())
 
     # [TODO] Implement sanity checks depending on the node kind
     if node.parent:


### PR DESCRIPTION
Fixes https://github.com/kernelci/kernelci-pipeline/issues/403

When submodel like `Checkout` or `Test` node is submitted, explicit validation takes place in `parse_node_obj` method. The method also converts request parameters to defined data types e.g. for storing kernel version, `version` and `patchlevel` fields will be converted to `int`.
Losing all these conversion and storing object as it received will raise issues like `kver` job failure.
In order to preserve type casting happened during validation in `parse_node_obj`, store it to `node`.
If we try to store this node object directly, it will raise issue while JSON serialization of `Node.data` field in `_get_node_event_data`. Also, DB will not be able to map collection name from submodel type as the collection dictionary uses only one collection for all kind of nodes i.e. `node`. Fixing above issues will also fix `kver` job failure.

Fixes: b785e19 ("api.main: use node endpoints for all type of Node subtypes")