### PR TITLE
pyproject.toml: add package directories such as templates and scripts

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,4 +51,8 @@ Documentation = "https://kernelci.org/docs"
 Repository = "https://github.com/kernelci/kernelci-api"
 
 [tool.setuptools]
-packages = ["api"]
+packages = ["api", "scripts", "templates"]
+
+[tool.setuptools.package-data]
+scripts = ["*"]
+templates = ["*.jinja2", "*.html"]


### PR DESCRIPTION
Only the `api` directory is included with the python package atm. Add directories such as templates and scripts to run API container properly to the package.