### PR TITLE
Move e2e tests script to `scripts/` directory

### DIFF
--- a/scripts/run_e2e_tests.sh
+++ b/scripts/run_e2e_tests.sh
@@ -2,12 +2,12 @@
 #
 # SPDX-License-Identifier: LGPL-2.1-or-later
 #
-# Copyright (C) 2023 Collabora Limited
+# Copyright (C) 2023-2024 Collabora Limited
 # Author: Jeny Sadadia <jeny.sadadia@collabora.com>
 
 # Script for running API end-to-end tests
 
 docker-compose -f test-docker-compose.yaml build
 docker-compose -f test-docker-compose.yaml up -d api db redis storage ssh test
-docker-compose -f test-docker-compose.yaml exec test pytest -v e2e_tests
+docker-compose -f test-docker-compose.yaml exec -T test pytest -v tests/e2e_tests
 docker-compose -f test-docker-compose.yaml down

--- a/test-docker-compose.yaml
+++ b/test-docker-compose.yaml
@@ -57,7 +57,6 @@ services:
     volumes:
       - './api:/home/kernelci/api'
       - './tests:/home/kernelci/tests'
-      - './tests/e2e_tests:/home/kernelci/e2e_tests'
     depends_on:
       - api
     env_file:


### PR DESCRIPTION
All the scripts are stored in the `scripts` directory.     Move `run_e2e_tests.sh` script to that directory as well.
Also, update the command running e2e tests to use `tests/e2e_tests` as `tests` container has mounted volume
`tests/`.
