### PR TITLE
Add build argument for `e2e` tests

### DIFF
--- a/scripts/run_e2e_tests.sh
+++ b/scripts/run_e2e_tests.sh
@@ -7,7 +7,7 @@
 
 # Script for running API end-to-end tests
 
-docker-compose -f test-docker-compose.yaml build
+docker-compose -f test-docker-compose.yaml build --no-cache
 docker-compose -f test-docker-compose.yaml up -d api db redis storage ssh test
 docker-compose -f test-docker-compose.yaml exec -T test pytest -v tests/e2e_tests
 docker-compose -f test-docker-compose.yaml down


### PR DESCRIPTION
Created on top of https://github.com/kernelci/kernelci-api/pull/490

scripts/run_e2e_tests: add build argument
    
Add `no-cache` build argument while building images for tests.