### PR TITLE
tests/e2e_tests: fix dependency markers

### DIFF
--- a/tests/e2e_tests/test_count_handler.py
+++ b/tests/e2e_tests/test_count_handler.py
@@ -12,7 +12,7 @@ import pytest
 
 @pytest.mark.dependency(
     depends=[
-        'e2e_tests/test_pipeline.py::test_node_pipeline'],
+        'tests/e2e_tests/test_pipeline.py::test_node_pipeline'],
     scope='session')
 def test_count_nodes(test_client):
     """
@@ -28,7 +28,7 @@ def test_count_nodes(test_client):
 
 @pytest.mark.dependency(
     depends=[
-        'e2e_tests/test_pipeline.py::test_node_pipeline'],
+        'tests/e2e_tests/test_pipeline.py::test_node_pipeline'],
     scope='session')
 def test_count_nodes_matching_attributes(test_client):
     """

--- a/tests/e2e_tests/test_password_handler.py
+++ b/tests/e2e_tests/test_password_handler.py
@@ -11,7 +11,7 @@ import pytest
 
 
 @pytest.mark.dependency(
-    depends=["e2e_tests/test_user_creation.py::test_create_regular_user"],
+    depends=["tests/e2e_tests/test_user_creation.py::test_create_regular_user"],
     scope="session",
 )
 @pytest.mark.order("last")

--- a/tests/e2e_tests/test_pipeline.py
+++ b/tests/e2e_tests/test_pipeline.py
@@ -15,7 +15,7 @@ from .test_node_handler import create_node, get_node_by_id, update_node
 
 @pytest.mark.dependency(
     depends=[
-        'e2e_tests/test_subscribe_handler.py::test_subscribe_node_channel'],
+        'tests/e2e_tests/test_subscribe_handler.py::test_subscribe_node_channel'],
     scope='session')
 @pytest.mark.order(4)
 @pytest.mark.asyncio

--- a/tests/e2e_tests/test_pubsub_handler.py
+++ b/tests/e2e_tests/test_pubsub_handler.py
@@ -13,7 +13,7 @@ from .listen_handler import create_listen_task
 
 
 @pytest.mark.dependency(
-    depends=['e2e_tests/test_subscribe_handler.py::test_subscribe_test_channel'],
+    depends=['tests/e2e_tests/test_subscribe_handler.py::test_subscribe_test_channel'],
     scope='session')
 @pytest.mark.asyncio
 async def test_pubsub_handler(test_async_client):

--- a/tests/e2e_tests/test_regression_handler.py
+++ b/tests/e2e_tests/test_regression_handler.py
@@ -13,7 +13,7 @@ from .test_node_handler import create_node, get_node_by_attribute
 
 @pytest.mark.dependency(
     depends=[
-        "e2e_tests/test_pipeline.py::test_node_pipeline"],
+        "tests/e2e_tests/test_pipeline.py::test_node_pipeline"],
     scope="session")
 @pytest.mark.asyncio
 async def test_regression_handler(test_async_client):

--- a/tests/e2e_tests/test_subscribe_handler.py
+++ b/tests/e2e_tests/test_subscribe_handler.py
@@ -10,7 +10,7 @@ import pytest
 
 
 @pytest.mark.dependency(
-    depends=['e2e_tests/test_user_creation.py::test_create_regular_user'],
+    depends=['tests/e2e_tests/test_user_creation.py::test_create_regular_user'],
     scope='session')
 @pytest.mark.order(3)
 def test_subscribe_node_channel(test_client):
@@ -33,7 +33,7 @@ def test_subscribe_node_channel(test_client):
 
 
 @pytest.mark.dependency(
-    depends=['e2e_tests/test_user_creation.py::test_create_regular_user'],
+    depends=['tests/e2e_tests/test_user_creation.py::test_create_regular_user'],
     scope='session')
 @pytest.mark.order(3)
 def test_subscribe_test_channel(test_client):
@@ -56,7 +56,7 @@ def test_subscribe_test_channel(test_client):
 
 
 @pytest.mark.dependency(
-    depends=['e2e_tests/test_user_creation.py::test_create_regular_user'],
+    depends=['tests/e2e_tests/test_user_creation.py::test_create_regular_user'],
     scope='session')
 @pytest.mark.order(3)
 def test_subscribe_user_group_channel(test_client):

--- a/tests/e2e_tests/test_unsubscribe_handler.py
+++ b/tests/e2e_tests/test_unsubscribe_handler.py
@@ -11,7 +11,7 @@ import pytest
 
 @pytest.mark.dependency(
     depends=[
-        'e2e_tests/test_subscribe_handler.py::test_subscribe_node_channel'],
+        'tests/e2e_tests/test_subscribe_handler.py::test_subscribe_node_channel'],
     scope='session')
 @pytest.mark.order("last")
 def test_unsubscribe_node_channel(test_client):
@@ -31,7 +31,7 @@ def test_unsubscribe_node_channel(test_client):
 
 @pytest.mark.dependency(
     depends=[
-        'e2e_tests/test_subscribe_handler.py::test_subscribe_test_channel'],
+        'tests/e2e_tests/test_subscribe_handler.py::test_subscribe_test_channel'],
     scope='session')
 @pytest.mark.order("last")
 def test_unsubscribe_test_channel(test_client):

--- a/tests/e2e_tests/test_user_creation.py
+++ b/tests/e2e_tests/test_user_creation.py
@@ -15,7 +15,7 @@ from .conftest import db_create
 
 
 @pytest.mark.dependency(
-    depends=["e2e_tests/test_user_group_handler.py::test_create_user_groups"],
+    depends=["tests/e2e_tests/test_user_group_handler.py::test_create_user_groups"],
     scope="session")
 @pytest.mark.dependency()
 @pytest.mark.order(1)

--- a/tests/e2e_tests/test_user_group_handler.py
+++ b/tests/e2e_tests/test_user_group_handler.py
@@ -14,7 +14,7 @@ from .listen_handler import create_listen_task
 
 @pytest.mark.dependency(
     depends=[
-        'e2e_tests/test_subscribe_handler.py::test_subscribe_user_group_channel'],
+        'tests/e2e_tests/test_subscribe_handler.py::test_subscribe_user_group_channel'],
     scope='session')
 @pytest.mark.asyncio
 async def test_create_and_get_user_group(test_async_client):


### PR DESCRIPTION
Related to https://github.com/kernelci/kernelci-api/pull/490

Docker container for running tests uses `tests` volume instead of `tests/e2e_tests` now. Update all the test dependency markers to use test file path starting from `tests/` accordingly.