### PR TITLE
workflows/test: add `--no-cache` build argument

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -36,7 +36,7 @@ jobs:
           echo "EMAIL_PASSWORD=random" >> .env
 
       - name: Build docker images
-        run: docker-compose -f test-docker-compose.yaml build
+        run: docker-compose -f test-docker-compose.yaml build --no-cache
 
       - name: Run API containers
         run: |


### PR DESCRIPTION
Add `--no-cache` build argument in the test workflows to fetch the latest docker image every time while building docker containers.