### PR TITLE
workflows/main: add `--no-cache` build argument

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -48,7 +48,7 @@ jobs:
           echo "EMAIL_PASSWORD=random" >> .env
 
       - name: Build docker images
-        run: docker-compose -f test-docker-compose.yaml build
+        run: docker-compose -f test-docker-compose.yaml build --no-cache
 
       - name: Run pycodestyle
         run: |


### PR DESCRIPTION
Add `--no-cache` build argument in the `main` workflow to fetch latest docker image every time while building docker containers.