### PR TITLE
api.main: fix `pylint` error

### DIFF
--- a/api/main.py
+++ b/api/main.py
@@ -738,8 +738,8 @@ async def viewer():
     """Serve simple HTML page to view the API /static/viewer.html
     Set various no-cache tag we might update it often"""
 
-    root = os.path.dirname(os.path.abspath(__file__))
-    viewer_path = os.path.join(root, 'templates', 'viewer.html')
+    root_dir = os.path.dirname(os.path.abspath(__file__))
+    viewer_path = os.path.join(root_dir, 'templates', 'viewer.html')
     with open(viewer_path, 'r', encoding='utf-8') as file:
         # set header to text/html and no-cache stuff
         hdr = {


### PR DESCRIPTION
Fix the below pylint error:
```
api/main.py:741:4: W0621: Redefining name 'root' from outer scope (line 112) (redefined-outer-name)
```