### PR TITLE
Add `docker-compose` file for developer mode

### DIFF
--- a/dev-docker-compose.yaml
+++ b/dev-docker-compose.yaml
@@ -1,0 +1,61 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+#
+# Copyright (C) 2024 Collabora Limited
+# Author: Jeny Sadadia <jeny.sadadia@collabora.com>
+
+version: '3'
+services:
+
+  api:
+    container_name: 'kernelci-api'
+    build:
+      context: 'docker/api'
+      args:
+        - REQUIREMENTS=${REQUIREMENTS:-requirements.txt}
+        - core_rev=${CORE_REV:-main}
+    volumes:
+      - './api:/home/kernelci/api'
+      - './tests:/home/kernelci/tests'
+      - './migrations:/home/kernelci/migrations'
+      - './templates:/home/kernelci/templates'
+    ports:
+      - '${API_HOST_PORT:-8001}:8000'
+    env_file:
+      - '.env'
+
+  db:
+    container_name: 'kernelci-api-db'
+    image: 'mongo:5.0'
+    command: '--wiredTigerCacheSizeGB=0.5'
+    ports:
+      - '${MONGO_HOST_PORT:-8017}:27017'
+    volumes:
+      - 'mongodata:/data/db'
+
+  redis:
+    container_name: 'kernelci-api-redis'
+    image: 'redis:6.2'
+    volumes:
+      - './docker/redis/data:/data'
+
+  storage:
+    container_name: 'kernelci-api-storage'
+    image: 'nginx:1.21.3'
+    volumes:
+      - './docker/storage/data:/usr/share/nginx/html'
+      - './docker/storage/config/default.conf:/etc/nginx/conf.d/default.conf'
+    ports:
+      - ${STORAGE_HOST_PORT:-8002}:80
+
+  ssh:
+    container_name: 'kernelci-api-ssh'
+    build:
+      context: 'docker/ssh'
+    volumes:
+      - './docker/storage/data:/home/kernelci/data'
+      - './docker/ssh/user-data:/home/kernelci/.ssh'
+    ports:
+      - '${SSH_HOST_PORT:-8022}:22'
+
+volumes:
+  mongodata:

--- a/docker/api/Dockerfile
+++ b/docker/api/Dockerfile
@@ -1,0 +1,41 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+#
+# Copyright (C) 2021 Collabora Limited
+# Author: Guillaume Tucker <guillaume.tucker@collabora.com>
+
+FROM python:3.10
+MAINTAINER "KernelCI TSC" <kernelci-tsc@groups.io>
+
+RUN apt-get update && apt-get install --no-install-recommends -y git
+
+# Upgrade pip3 - never mind the warning about running this as root
+RUN pip3 install --upgrade pip
+
+# Create kernelci user
+RUN useradd kernelci -u 1000 -d /home/kernelci -s /bin/bash
+RUN mkdir -p /home/kernelci
+RUN chown kernelci: /home/kernelci
+USER kernelci
+ENV PATH=$PATH:/home/kernelci/.local/bin
+WORKDIR /home/kernelci
+
+# Install requirements
+COPY requirements*.txt /home/kernelci/
+ARG REQUIREMENTS=requirements.txt
+RUN pip install --requirement ${REQUIREMENTS}
+
+# Install kernelci Python package from kernelci-core
+USER root
+ARG core_url=https://github.com/kernelci/kernelci-core.git
+ARG core_rev=main
+RUN git clone --depth=1 $core_url /tmp/kernelci-core
+WORKDIR /tmp/kernelci-core
+RUN git fetch origin $core_rev
+RUN git checkout FETCH_HEAD
+RUN python3 -m pip install .
+RUN cp -R config /etc/kernelci/
+WORKDIR /home/kernelci
+RUN rm -rf /tmp/kernelci-core
+USER kernelci
+
+CMD ["uvicorn", "api.main:versioned_app", "--host", "0.0.0.0", "--reload"]


### PR DESCRIPTION
Enable developer to use local volume binds by adding `dev-docker-compose.yaml` file. Also, add `Dockerfile` to provide the ability to build `api` container locally. This file is intended for developer use only.