### PR TITLE
T40464 Upgrade API to python 3.11

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -20,7 +20,7 @@ jobs:
 
     strategy:
       matrix:
-        python-version: ['3.10'] # Only supported one at the moment
+        python-version: ['3.10', '3.11']
 
     steps:
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,7 +20,7 @@ jobs:
 
     strategy:
       matrix:
-        python-version: ['3.10'] # Only supported one at the moment
+        python-version: ['3.10', '3.11']
 
     steps:
 

--- a/api/main.py
+++ b/api/main.py
@@ -10,7 +10,7 @@
 
 import os
 import re
-from typing import List
+from typing import List, Union
 from fastapi import (
     Depends,
     FastAPI,
@@ -387,7 +387,7 @@ async def get_user_groups(request: Request):
     return paginated_resp
 
 
-@app.get('/group/{group_id}', response_model=UserGroup,
+@app.get('/group/{group_id}', response_model=Union[UserGroup, None],
          response_model_by_alias=False)
 async def get_group(group_id: str):
     """Get user group information from the provided group id"""
@@ -448,7 +448,7 @@ async def translate_null_query_params(query_params: dict):
     return translated
 
 
-@app.get('/node/{node_id}', response_model=Node,
+@app.get('/node/{node_id}', response_model=Union[Node, None],
          response_model_by_alias=False)
 async def get_node(node_id: str):
     """Get node information from the provided node id"""

--- a/docker/api/Dockerfile
+++ b/docker/api/Dockerfile
@@ -1,9 +1,10 @@
 # SPDX-License-Identifier: LGPL-2.1-or-later
 #
-# Copyright (C) 2021 Collabora Limited
+# Copyright (C) 2021-2024 Collabora Limited
 # Author: Guillaume Tucker <guillaume.tucker@collabora.com>
+# Author: Jeny Sadadia <jeny.sadadia@collabora.com>
 
-FROM python:3.10
+FROM python:3.11
 MAINTAINER "KernelCI TSC" <kernelci-tsc@groups.io>
 
 RUN apt-get update && apt-get install --no-install-recommends -y git

--- a/docker/api/requirements-dev.txt
+++ b/docker/api/requirements-dev.txt
@@ -1,3 +1,3 @@
 -r requirements-tests.txt
 pycodestyle==2.8.0
-pylint==2.12.2
+pylint==3.1.0

--- a/docker/api/requirements.txt
+++ b/docker/api/requirements.txt
@@ -1,14 +1,13 @@
 cloudevents==1.9.0
-fastapi[all]==0.68.1
+fastapi[all]==0.99.1
 fastapi-pagination==0.9.3
 fastapi-users[beanie, oauth]==10.4.0
 fastapi-versioning==0.10.0
 MarkupSafe==2.0.1
-motor==2.5.1
+motor==3.3.2
 passlib==1.7.4
 pydantic==1.10.5
 pymongo-migrate==0.11.0
 python-jose[cryptography]==3.3.0
-pyyaml==5.3.1
 redis==5.0.1
-uvicorn[standard]==0.13.4
+uvicorn[standard]==0.29.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,19 +13,18 @@ requires-python = ">=3.10"
 license = {text = "LGPL-2.1-or-later"}
 dependencies = [
   "cloudevents == 1.9.0",
-  "fastapi[all] == 0.68.1",
+  "fastapi[all] == 0.99.1",
   "fastapi-pagination == 0.9.3",
   "fastapi-users[beanie, oauth] == 10.4.0",
   "fastapi-versioning == 0.10.0",
   "MarkupSafe == 2.0.1",
-  "motor == 2.5.1",
+  "motor == 3.3.2",
   "passlib == 1.7.4",
   "pydantic == 1.10.5",
   "pymongo-migrate == 0.11.0",
   "python-jose[cryptography] == 3.3.0",
-  "pyyaml == 5.3.1",
   "redis == 5.0.1",
-  "uvicorn[standard] == 0.13.4",
+  "uvicorn[standard] == 0.29.0",
 ]
 
 [project.optional-dependencies]
@@ -42,7 +41,7 @@ tests = [
 dev = [
   "kernelci-api[tests]",
   "pycodestyle == 2.8.0",
-  "pylint == 2.12.2",
+  "pylint == 3.1.0",
 ]
 
 [project.urls]

--- a/tests/e2e_tests/conftest.py
+++ b/tests/e2e_tests/conftest.py
@@ -10,8 +10,6 @@ import pytest
 from httpx import AsyncClient
 from motor.motor_asyncio import AsyncIOMotorClient
 
-from fastapi.testclient import TestClient
-
 from api.main import versioned_app
 from kernelci.api.models import Node, Regression
 
@@ -29,12 +27,6 @@ paginated_response_keys = {
     'limit',
     'offset',
 }
-
-@pytest.fixture(scope='session')
-def test_client():
-    """Fixture to get FastAPI Test client instance"""
-    with TestClient(app=versioned_app, base_url=BASE_URL) as client:
-        yield client
 
 
 @pytest.fixture(scope='session')

--- a/tests/e2e_tests/test_count_handler.py
+++ b/tests/e2e_tests/test_count_handler.py
@@ -10,33 +10,35 @@
 import pytest
 
 
+@pytest.mark.asyncio
 @pytest.mark.dependency(
     depends=[
         'tests/e2e_tests/test_pipeline.py::test_node_pipeline'],
     scope='session')
-def test_count_nodes(test_client):
+async def test_count_nodes(test_async_client):
     """
     Test Case : Test KernelCI API GET /count endpoint
     Expected Result :
         HTTP Response Code 200 OK
         Total number of nodes available
     """
-    response = test_client.get("count")
+    response = await test_async_client.get("count")
     assert response.status_code == 200
     assert response.json() >= 0
 
 
+@pytest.mark.asyncio
 @pytest.mark.dependency(
     depends=[
         'tests/e2e_tests/test_pipeline.py::test_node_pipeline'],
     scope='session')
-def test_count_nodes_matching_attributes(test_client):
+async def test_count_nodes_matching_attributes(test_async_client):
     """
     Test Case : Test KernelCI API GET /count endpoint with attributes
     Expected Result :
         HTTP Response Code 200 OK
         Number of nodes matching attributes
     """
-    response = test_client.get("count?name=checkout")
+    response = await test_async_client.get("count?name=checkout")
     assert response.status_code == 200
     assert response.json() >= 0

--- a/tests/e2e_tests/test_root_handler.py
+++ b/tests/e2e_tests/test_root_handler.py
@@ -5,9 +5,12 @@
 
 """End-to-end test functions for KernelCI API root handler"""
 
+import pytest
 
-def test_root_endpoint(test_client):
+
+@pytest.mark.asyncio
+async def test_root_endpoint(test_async_client):
     """Test root handler"""
-    response = test_client.get("/latest")
+    response = await test_async_client.get("/")
     assert response.status_code == 200
     assert response.json() == {"message": "KernelCI API"}

--- a/tests/e2e_tests/test_subscribe_handler.py
+++ b/tests/e2e_tests/test_subscribe_handler.py
@@ -9,18 +9,19 @@
 import pytest
 
 
+@pytest.mark.asyncio
 @pytest.mark.dependency(
     depends=['tests/e2e_tests/test_user_creation.py::test_create_regular_user'],
     scope='session')
 @pytest.mark.order(3)
-def test_subscribe_node_channel(test_client):
+async def test_subscribe_node_channel(test_async_client):
     """
     Test Case : Test KernelCI API '/subscribe' endpoint with 'node' channel
     Expected Result :
         HTTP Response Code 200 OK
         JSON with subscription 'id' and 'channel' keys
     """
-    response = test_client.post(
+    response = await test_async_client.post(
         "subscribe/node",
         headers={
             "Authorization": f"Bearer {pytest.BEARER_TOKEN}"  # pylint: disable=no-member
@@ -32,18 +33,19 @@ def test_subscribe_node_channel(test_client):
     assert response.json().get('channel') == 'node'
 
 
+@pytest.mark.asyncio
 @pytest.mark.dependency(
     depends=['tests/e2e_tests/test_user_creation.py::test_create_regular_user'],
     scope='session')
 @pytest.mark.order(3)
-def test_subscribe_test_channel(test_client):
+async def test_subscribe_test_channel(test_async_client):
     """
     Test Case : Test KernelCI API '/subscribe' endpoint with 'test_channel'
     Expected Result :
         HTTP Response Code 200 OK
         JSON with subscription 'id' and 'channel' keys
     """
-    response = test_client.post(
+    response = await test_async_client.post(
         "subscribe/test_channel",
         headers={
             "Authorization": f"Bearer {pytest.BEARER_TOKEN}"  # pylint: disable=no-member
@@ -55,11 +57,12 @@ def test_subscribe_test_channel(test_client):
     assert response.json().get('channel') == 'test_channel'
 
 
+@pytest.mark.asyncio
 @pytest.mark.dependency(
     depends=['tests/e2e_tests/test_user_creation.py::test_create_regular_user'],
     scope='session')
 @pytest.mark.order(3)
-def test_subscribe_user_group_channel(test_client):
+async def test_subscribe_user_group_channel(test_async_client):
     """
     Test Case : Test KernelCI API '/subscribe' endpoint with 'user_group'
     channel
@@ -67,7 +70,7 @@ def test_subscribe_user_group_channel(test_client):
         HTTP Response Code 200 OK
         JSON with subscription 'id' and 'channel' keys
     """
-    response = test_client.post(
+    response = await test_async_client.post(
         "subscribe/user_group",
         headers={
             "Authorization": f"Bearer {pytest.BEARER_TOKEN}"  # pylint: disable=no-member

--- a/tests/e2e_tests/test_unsubscribe_handler.py
+++ b/tests/e2e_tests/test_unsubscribe_handler.py
@@ -9,18 +9,19 @@
 import pytest
 
 
+@pytest.mark.asyncio
 @pytest.mark.dependency(
     depends=[
         'tests/e2e_tests/test_subscribe_handler.py::test_subscribe_node_channel'],
     scope='session')
 @pytest.mark.order("last")
-def test_unsubscribe_node_channel(test_client):
+async def test_unsubscribe_node_channel(test_async_client):
     """
     Test Case : Test KernelCI API '/unsubscribe' endpoint with 'node' channel
     Expected Result :
         HTTP Response Code 200 OK
     """
-    response = test_client.post(
+    response = await test_async_client.post(
         f"unsubscribe/{pytest.node_channel_subscription_id}",  # pylint: disable=no-member
         headers={
             "Authorization": f"Bearer {pytest.BEARER_TOKEN}"  # pylint: disable=no-member
@@ -29,18 +30,19 @@ def test_unsubscribe_node_channel(test_client):
     assert response.status_code == 200
 
 
+@pytest.mark.asyncio
 @pytest.mark.dependency(
     depends=[
         'tests/e2e_tests/test_subscribe_handler.py::test_subscribe_test_channel'],
     scope='session')
 @pytest.mark.order("last")
-def test_unsubscribe_test_channel(test_client):
+async def test_unsubscribe_test_channel(test_async_client):
     """
     Test Case : Test KernelCI API '/unsubscribe' endpoint with 'test_channel'
     Expected Result :
         HTTP Response Code 200 OK
     """
-    response = test_client.post(
+    response = await test_async_client.post(
         f"unsubscribe/{pytest.test_channel_subscription_id}",  # pylint: disable=no-member
         headers={
             "Authorization": f"Bearer {pytest.BEARER_TOKEN}"  # pylint: disable=no-member

--- a/tests/e2e_tests/test_user_creation.py
+++ b/tests/e2e_tests/test_user_creation.py
@@ -118,8 +118,9 @@ async def test_create_regular_user(test_async_client):
     pytest.BEARER_TOKEN = response.json()['access_token']
 
 
+@pytest.mark.asyncio
 @pytest.mark.dependency(depends=["test_create_regular_user"])
-def test_whoami(test_client):
+async def test_whoami(test_async_client):
     """
     Test Case : Test KernelCI API /whoami endpoint
     Expected Result :
@@ -127,7 +128,7 @@ def test_whoami(test_client):
         JSON with 'id', 'email', username', 'groups', 'is_superuser'
         'is_verified' and 'is_active' keys
     """
-    response = test_client.get(
+    response = await test_async_client.get(
         "whoami",
         headers={
             "Accept": "application/json",
@@ -140,8 +141,9 @@ def test_whoami(test_client):
     assert response.json()['username'] == 'test_user'
 
 
+@pytest.mark.asyncio
 @pytest.mark.dependency(depends=["test_create_regular_user"])
-def test_create_user_negative(test_client):
+async def test_create_user_negative(test_async_client):
     """
     Test Case : Test KernelCI API /user/register endpoint when requested
     with regular user's bearer token.
@@ -149,7 +151,7 @@ def test_create_user_negative(test_client):
         HTTP Response Code 403 Forbidden
         JSON with 'detail' key denoting 'Forbidden' error
     """
-    response = test_client.post(
+    response = await test_async_client.post(
         "user/register",
         headers={
                 "Accept": "application/json",

--- a/tests/unit_tests/conftest.py
+++ b/tests/unit_tests/conftest.py
@@ -90,7 +90,7 @@ def mock_get_current_admin_user(request: Request):
         is_verified=True
     )
 
-
+# Mock dependency callables for getting current user
 app.dependency_overrides[get_current_user] = mock_get_current_user
 app.dependency_overrides[get_current_superuser] = mock_get_current_admin_user
 
@@ -98,7 +98,6 @@ app.dependency_overrides[get_current_superuser] = mock_get_current_admin_user
 @pytest.fixture(scope='session')
 def test_client():
     """Fixture to get FastAPI Test client instance"""
-    # Mock dependency callables for getting current user
     with TestClient(app=versioned_app, base_url=BASE_URL) as client:
         yield client
 


### PR DESCRIPTION
Fixes https://github.com/kernelci/kernelci-api/issues/479

Upgrade Python version to 3.11 for API. Update docker recipe that is being used for Developer mode to use `Python 3.11` image.
Update requirements version to enable support for Python 3.11.
Below are the required changes:
- `httptools` that is a requirement for `uvicorn`, failed to
    build for existing package version that was `0.13.4`.
```
    gcc -Wsign-compare -DNDEBUG -g -fwrapv -O3 -Wall -fPIC -I/usr/local/include/python3.11 -I/tmp/pip-install-o_24u7rm/httptools_8955220ea3f34d0bae14ed2b27b468ae/vendor/http-parser -c httptools/parser/parser.c -o build/temp.linux-x86_64-cpython-311/httptools/parser/parser.o -O2
    httptools/parser/parser.c:212:12: fatal error: longintrepr.h: No such file or directory
    212 |   #include "longintrepr.h"
           |            ^~~~~~~~~~~~~~~
    compilation terminated.
    error: command '/usr/bin/gcc' failed with exit code 1
    [end of output]    
    note: This error originates from a subprocess, and is likely not a problem with pip.
    ERROR: Failed building wheel for httptools
```
Fix it by using `uvicorn` version with Python 3.11 support i.e. `0.29.0`.
- Since `uvicorn` is one of the requirements of `fastapi`, we also need to update its version to make it compatible with `uvicorn`. The fastapi version `0.99.1` has been selected to avoid dependency conflicts with
existing `fastapi-users` version i.e. `10.4.0`. Otherwise the below build failure will take place:
```
    ERROR: Cannot install fastapi-users, fastapi-users[beanie,oauth]==10.4.0 and fastapi[all]==0.110.0 because
    these package versions have conflicting dependencies.
```
- `fastapi==0.99.1` also removes the requirement of pinning `pyyaml` version.
Dropped: 473bd7b ("docker/api: pin PyYAML version to 5.3.1")
- Also, upgrade `motor` version to use it with python 3.11.
- Upgrade `pylint` to the latest version i.e. `3.1.0`to resolve below incompatibility issue from `wrapt` package:
```
    File "/usr/local/lib/python3.11/site-packages/wrapt/decorators.py", line 34, in <module>
        from inspect import ismethod, isclass, formatargspec
    ImportError: cannot import name 'formatargspec' from 'inspect' (/usr/local/lib/python3.11/inspect.py)
```

