### PR TITLE
Use `kernelci` tag for `kernelci/staging-api` image

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -8,7 +8,7 @@ services:
 
   api:
     container_name: 'kernelci-api'
-    image: ${KERNELCI_API_IMAGE:-kernelci/staging-api}:${KERNELCI_API_TAG:-latest}
+    image: ${KERNELCI_API_IMAGE:-kernelci/staging-kernelci}:${KERNELCI_API_TAG:-api}
     ports:
       - '${API_HOST_PORT:-8001}:8000'
     env_file:

--- a/test-docker-compose.yaml
+++ b/test-docker-compose.yaml
@@ -8,7 +8,7 @@ services:
 
   api:
     container_name: 'test-kernelci-api'
-    image: '${KERNELCI_API_IMAGE:-kernelci/staging-api}:${KERNELCI_API_TAG:-latest}'
+    image: '${KERNELCI_API_IMAGE:-kernelci/staging-kernelci}:${KERNELCI_API_TAG:-api}'
     ports:
       - '${API_HOST_PORT:-8001}:8000'
     env_file:
@@ -50,7 +50,7 @@ services:
 
   test:
     container_name: 'kernelci-api-tests'
-    image: '${KERNELCI_API_IMAGE:-kernelci/staging-api}:${KERNELCI_API_TAG:-latest}'
+    image: '${KERNELCI_API_IMAGE:-kernelci/staging-kernelci}:${KERNELCI_API_TAG:-api}'
     volumes:
       - './api:/home/kernelci/api'
       - './tests:/home/kernelci/tests'


### PR DESCRIPTION
Depends on https://github.com/kernelci/kernelci-core/pull/2485

Template for building `api` docker image has been updated to use `kernelci` fragment for using `kernelci` python package.
Hence, use `kernelci` tag for `kernelci/staging-api` image.