### PR TITLE
api/config: Add token expiration

### DIFF
--- a/api/config.py
+++ b/api/config.py
@@ -13,7 +13,7 @@ class AuthSettings(BaseSettings):
     secret_key: str
     algorithm: str = "HS256"
     # Set to None so tokens don't expire
-    access_token_expire_seconds: float = None
+    access_token_expire_seconds: float = 315360000
 
 
 class PubSubSettings(BaseSettings):


### PR DESCRIPTION
To have at least some token variability we need to add more entropy. Setting expiration to 10 years might be enough, as it will force token signed data to include this information.