### PR TITLE
doc: remove paragraph with Atlas graph

### DIFF
--- a/doc/_index.md
+++ b/doc/_index.md
@@ -28,12 +28,6 @@ step that produced the node passed or failed.  Finally there's a list of
 artifacts with URLs to know where to find all the related files (binaries,
 logs, generated results etc.).
 
-Here's a publicly available
-[graph](https://charts.mongodb.com/charts-kernelci-api-staging-otxuy/public/dashboards/5b52c3c6-81bb-4658-a5f3-8ebd2e980436#)
-showing the number of nodes added to the database every day:
-
-<div style="padding: 0 0 20px 0"><iframe style="background: #FFFFFF;border: none;border-radius: 2px;box-shadow: 0 2px 10px 0 rgba(70, 76, 79, .2);" width="640" height="480" src="https://charts.mongodb.com/charts-kernelci-api-staging-otxuy/embed/charts?id=64c9fa16-ba81-40e9-8cd7-cd56fb88fbf3&maxDataAge=3600&theme=light&autoRefresh=true"></iframe></div>
-
 > **Note:** The API doesn't manage storage, the only requirement is to provide
 > publicly-available HTTP(S) URLs for each artifact.
 


### PR DESCRIPTION
The temporary Atlas account which was created for Early Access is now being closed, and as a result the link to the dashboard will stop working.  Remove the paragraph with the embedded Atlas dashboard graph showing the number of nodes.