### PR TITLE
api.main: add `is_hierarchy` to node event data

### DIFF
--- a/api/main.py
+++ b/api/main.py
@@ -437,7 +437,7 @@ async def delete_group(group_id: str,
 # -----------------------------------------------------------------------------
 # Nodes
 
-def _get_node_event_data(operation, node):
+def _get_node_event_data(operation, node, is_hierarchy=False):
     return {
         'op': operation,
         'id': str(node.id),
@@ -449,6 +449,7 @@ def _get_node_event_data(operation, node):
         'result': node.result,
         'owner': node.owner,
         'data': node.data,
+        'is_hierarchy': is_hierarchy,
     }
 
 
@@ -662,7 +663,7 @@ async def put_nodes(
     submitter = calculate_submitter(authorization)
     await _set_node_ownership_recursively(user, nodes, submitter)
     obj_list = await db.create_hierarchy(nodes, Node)
-    data = _get_node_event_data('updated', obj_list[0])
+    data = _get_node_event_data('updated', obj_list[0], True)
     attributes = {}
     if data.get('owner', None):
         attributes['owner'] = data['owner']

--- a/tests/e2e_tests/test_pipeline.py
+++ b/tests/e2e_tests/test_pipeline.py
@@ -62,7 +62,7 @@ async def test_node_pipeline(test_async_client):
     event_data = from_json(task_listen.result().json().get('data')).data
     assert event_data != 'BEEP'
     keys = {'op', 'id', 'kind', 'name', 'path',
-            'group', 'state', 'result', 'owner', 'data'}
+            'group', 'state', 'result', 'owner', 'data', 'is_hierarchy'}
     assert keys == event_data.keys()
     assert event_data.get('op') == 'created'
     assert event_data.get('id') == response.json()['id']
@@ -85,6 +85,6 @@ async def test_node_pipeline(test_async_client):
     event_data = from_json(task_listen.result().json().get('data')).data
     assert event_data != 'BEEP'
     keys = {'op', 'id', 'kind', 'name', 'path',
-            'group', 'state', 'result', 'owner', 'data'}
+            'group', 'state', 'result', 'owner', 'data', 'is_hierarchy'}
     assert keys == event_data.keys()
     assert event_data.get('op') == 'updated'


### PR DESCRIPTION
Add a boolean key named `is_hierarchy` node event data that denotes if the node event represents submission of node hierarchy. It would be required to distinguish such events from single node create/update events.