### PR TITLE
api: Implement pub/sub promisc mode

### DIFF
--- a/api/main.py
+++ b/api/main.py
@@ -11,7 +11,7 @@
 import os
 import re
 import hashlib
-from typing import List, Union
+from typing import List, Union, Optional
 from fastapi import (
     Depends,
     FastAPI,
@@ -19,7 +19,8 @@ from fastapi import (
     status,
     Request,
     Form,
-    Header
+    Header,
+    Query
 )
 from fastapi.responses import JSONResponse, PlainTextResponse, FileResponse
 from fastapi.security import OAuth2PasswordRequestForm
@@ -674,9 +675,13 @@ async def put_nodes(
 # Pub/Sub
 
 @app.post('/subscribe/{channel}', response_model=Subscription)
-async def subscribe(channel: str, user: User = Depends(get_current_user)):
+async def subscribe(channel: str, user: User = Depends(get_current_user),
+                    promisc: Optional[bool] = Query(None)):
     """Subscribe handler for Pub/Sub channel"""
-    return await pubsub.subscribe(channel, user.username)
+    options = {}
+    if promisc:
+        options['promiscuous'] = promisc
+    return await pubsub.subscribe(channel, user.username, options)
 
 
 @app.post('/unsubscribe/{sub_id}')

--- a/api/models.py
+++ b/api/models.py
@@ -45,6 +45,9 @@ class Subscription(BaseModel):
         description=("Username of the user that created the "
                      "subscription (owner)")
     )
+    promiscuous: bool = Field(
+        description='Listen to all users messages',
+        default=False)
 
 
 class SubscriptionStats(Subscription):

--- a/tests/e2e_tests/test_subscribe_handler.py
+++ b/tests/e2e_tests/test_subscribe_handler.py
@@ -29,7 +29,10 @@ async def test_subscribe_node_channel(test_async_client):
     )
     pytest.node_channel_subscription_id = response.json()['id']
     assert response.status_code == 200
-    assert ('id', 'channel', 'user') == tuple(response.json().keys())
+    # only id, channel, user is mandatory in the response
+    assert 'id' in response.json()
+    assert 'channel' in response.json()
+    assert 'user' in response.json()
     assert response.json().get('channel') == 'node'
 
 
@@ -53,7 +56,10 @@ async def test_subscribe_test_channel(test_async_client):
     )
     pytest.test_channel_subscription_id = response.json()['id']
     assert response.status_code == 200
-    assert ('id', 'channel', 'user') == tuple(response.json().keys())
+    # only id, channel, user is mandatory in the response
+    assert 'id' in response.json()
+    assert 'channel' in response.json()
+    assert 'user' in response.json()
     assert response.json().get('channel') == 'test_channel'
 
 
@@ -78,5 +84,8 @@ async def test_subscribe_user_group_channel(test_async_client):
     )
     pytest.user_group_channel_subscription_id = response.json()['id']
     assert response.status_code == 200
-    assert ('id', 'channel', 'user') == tuple(response.json().keys())
+    # only id, channel, user is mandatory in the response
+    assert 'id' in response.json()
+    assert 'channel' in response.json()
+    assert 'user' in response.json()
     assert response.json().get('channel') == 'user_group'

--- a/tests/unit_tests/test_subscribe_handler.py
+++ b/tests/unit_tests/test_subscribe_handler.py
@@ -29,4 +29,7 @@ def test_subscribe_endpoint(mock_subscribe, test_client):
     )
     print("response.json()", response.json())
     assert response.status_code == 200
-    assert ('id', 'channel', 'user') == tuple(response.json().keys())
+    # verify that id, channel, user are mandatory keys in the response
+    assert "id" in response.json()
+    assert "channel" in response.json()
+    assert "user" in response.json()


### PR DESCRIPTION
Some labs need to subscribe to all events, so they can receive other users kernel builds. Implement optional "promiscuous" option to make subscription listen to all users events.