### PR TITLE
api.main: fix POST `/user/update_password` endpoint

### DIFF
--- a/api/main.py
+++ b/api/main.py
@@ -344,7 +344,7 @@ async def get_users(request: Request,
     return paginated_resp
 
 
-@app.post("/user/update-password", response_model=UserRead, tags=["user"])
+@app.post("/user/update-password", tags=["user"])
 async def update_password(request: Request,
                           credentials: OAuth2PasswordRequestForm = Depends(),
                           new_password: str = Form(None)):


### PR DESCRIPTION
Fixes https://github.com/kernelci/kernelci-api/issues/534

Fix the below validation error while requesting user password update:
```
{"detail":"1 validation error for UserRead\nresponse\n  none is not an
allowed value (type=type_error.none.not_allowed)"}
```
The endpoint returns null on successful request even if response model is specified (and it's not None).