### PR TITLE
api: templates: viewer: add missing LAVA URLs

### DIFF
--- a/api/templates/viewer.html
+++ b/api/templates/viewer.html
@@ -136,9 +136,11 @@
         var lava_urls = {
             "lava-baylibre": "lava.baylibre.com",
             "lava-broonie": "lava.sirena.org.uk",
+            "lava-cip": "lava.ciplatform.org",
             "lava-collabora": "lava.collabora.dev",
             "lava-collabora-early-access": "staging.lava.collabora.dev",
             "lava-collabora-staging": "staging.lava.collabora.dev",
+            "lava-qualcomm": "lava.infra.foundries.io",
         };
 
         function fancydisplayjson(jsontext) {


### PR DESCRIPTION
Since the "LAVA Job" button was first implemented, a few LAVA labs have been connected to KernelCI. Using the "LAVA Job" button for jobs scheduled on those would then error out, the base URL being `undefined`.

Add the missing labs so we can more easily inspect LAVA logs and job definitions.