### PR TITLE
api.main: remove default `node.submitter`

### DIFF
--- a/api/main.py
+++ b/api/main.py
@@ -572,9 +572,6 @@ async def post_node(node: Node,
 
     await _verify_user_group_existence(node.user_groups)
     node.owner = current_user.username
-    # if node.submitter is not set, set it to "pipeline"
-    if not node.submitter:
-        node.submitter = "service:pipeline"
 
     # The node is handled as a generic Node by the DB, regardless of its
     # specific kind. The concrete Node submodel (Kbuild, Checkout, etc.)


### PR DESCRIPTION
Remove the hack of setting `node.submitter` field. The pipeline service and `kci_maintainer` tool should set the field instead while submitting node.