### PR TITLE
pyproject.toml: include `migration` script to package

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,8 +51,9 @@ Documentation = "https://docs.kernelci.org"
 Repository = "https://github.com/kernelci/kernelci-api"
 
 [tool.setuptools]
-packages = ["api", "scripts", "api.templates"]
+packages = ["api", "scripts", "api.templates", "migrations"]
 
 [tool.setuptools.package-data]
 scripts = ["*"]
 "api.templates" = ["*.jinja2", "*.html", "*.png"]
+migrations = ["*.py"]


### PR DESCRIPTION
Closes https://github.com/kernelci/kernelci-api/issues/513

Include migration script with `kernelci-api` python package for developer requirements.