### PR TITLE
api.main: fix delete user group endpoint

### DIFF
--- a/api/main.py
+++ b/api/main.py
@@ -25,7 +25,7 @@ from fastapi import (
 )
 from fastapi.responses import JSONResponse, PlainTextResponse, FileResponse
 from fastapi.security import OAuth2PasswordRequestForm
-from fastapi_pagination import add_pagination
+from fastapi_pagination import add_pagination, pagination_ctx
 from fastapi_versioning import VersionedFastAPI
 from bson import ObjectId, errors
 from pymongo.errors import DuplicateKeyError
@@ -415,7 +415,9 @@ async def get_group(group_id: str):
     return await db.find_by_id(UserGroup, group_id)
 
 
-@app.delete('/group/{group_id}', response_model=PageModel)
+@app.delete('/group/{group_id}',
+            dependencies=[Depends(pagination_ctx(PageModel))],
+            status_code=status.HTTP_204_NO_CONTENT)
 async def delete_group(group_id: str,
                        current_user: User = Depends(get_current_superuser)):
     """Delete user group matching the provided group id"""


### PR DESCRIPTION
Fixes https://github.com/kernelci/kernelci-api/issues/427

Fix `DELETE /group/{group-id}` endpoint's response model by using `pagination_ctx`.