### PR TITLE
Fix pydantic v2 warnings related to `UserGroup`

### DIFF
--- a/api/models.py
+++ b/api/models.py
@@ -121,8 +121,8 @@ class UserRead(schemas.BaseUser[PydanticObjectId], ModelId):
         return groups
 
 
-class UserCreate(schemas.BaseUserCreate):
-    """Schema for creating a user"""
+class UserCreateRequest(schemas.BaseUserCreate):
+    """Create user request schema for API router"""
     username: Annotated[str, Indexed(unique=True)]
     groups: List[str] = Field(default=[])
 
@@ -135,8 +135,22 @@ class UserCreate(schemas.BaseUserCreate):
         return groups
 
 
-class UserUpdate(schemas.BaseUserUpdate):
-    """Schema for updating a user"""
+class UserCreate(schemas.BaseUserCreate):
+    """Schema used for sending create user request to 'fastapi-users' router"""
+    username: Annotated[str, Indexed(unique=True)]
+    groups: List[UserGroup] = Field(default=[])
+
+    @field_validator('groups')
+    def validate_groups(cls, groups):   # pylint: disable=no-self-argument
+        """Unique group constraint"""
+        unique_names = {group.name for group in groups}
+        if len(unique_names) != len(groups):
+            raise ValueError("Groups must have unique names.")
+        return groups
+
+
+class UserUpdateRequest(schemas.BaseUserUpdate):
+    """Update user request schema for API router"""
     username: Annotated[Optional[str], Indexed(unique=True),
                         Field(default=None)]
     groups: List[str] = Field(default=[])
@@ -145,6 +159,21 @@ class UserUpdate(schemas.BaseUserUpdate):
     def validate_groups(cls, groups):   # pylint: disable=no-self-argument
         """Unique group constraint"""
         unique_names = set(groups)
+        if len(unique_names) != len(groups):
+            raise ValueError("Groups must have unique names.")
+        return groups
+
+
+class UserUpdate(schemas.BaseUserUpdate):
+    """Schema used for sending update user request to 'fastapi-users' router"""
+    username: Annotated[Optional[str], Indexed(unique=True),
+                        Field(default=None)]
+    groups: List[UserGroup] = Field(default=[])
+
+    @field_validator('groups')
+    def validate_groups(cls, groups):   # pylint: disable=no-self-argument
+        """Unique group constraint"""
+        unique_names = {group.name for group in groups}
         if len(unique_names) != len(groups):
             raise ValueError("Groups must have unique names.")
         return groups


### PR DESCRIPTION
Related to https://github.com/kernelci/kernelci-api/issues/560

Fix the below warnings from pydantic v2 while creating or updating a user account with user groups:
```
kernelci-api          | /home/kernelci/.local/lib/python3.11/site-packages/pydantic/main.py:390: UserWarning: Pydantic serializer warnings:
kernelci-api          |   Expected `str` but got `UserGroup` with value `UserGroup(id=ObjectId('64...16ad'), name='kernelci')` - serialized value may not be as expected
kernelci-api          |   return self.__pydantic_serializer__.to_python(
```

Fix the issue by defining and using different user models for API endpoint and fastapi-users router, i.e. different
models as request schema for API request model and schema for request to `fastapi-users` router.
For create user request, user needs to send `UserCreateRequest` schema as API router request
and the router will use `UserCreate` schema to send the request to `fastapi-users` router.
This is due to, we intend to have a list of user group name strings as API router request and `UserGroup`  instance as `fastapi-users` router request as `user.groups` field value.


