### PR TITLE
api.db: fix `Database.update` method

### DIFF
--- a/api/db.py
+++ b/api/db.py
@@ -278,9 +278,10 @@ class Database:
         if obj.id is None:
             raise ValueError("Cannot update object with no id")
         col = self._get_collection(obj.__class__)
-        obj.update()
-        if obj.parent == obj.id:
-            raise ValueError("Parent cannot be the same as the object")
+        if obj.__class__ == Node:
+            obj.update()
+            if obj.parent == obj.id:
+                raise ValueError("Parent cannot be the same as the object")
         res = await col.replace_one(
             {'_id': ObjectId(obj.id)}, obj.dict(by_alias=True)
         )


### PR DESCRIPTION
Fixes https://github.com/kernelci/kernelci-api/issues/575

Database `update` method was breaking while creating a `User` model with `is_superuser=1` field value.
Fix the method by separating `Node` specific logic from other model updates based on below facts:
- `obj.update()` will trigger `BeanieBaseUser.update()` for `User` model and not `DatabaseModel.update()`
- `User` model doesn't have `parent` field