### PR TITLE
tests/unit_tests: sync unit tests after model changes

### DIFF
--- a/tests/unit_tests/test_node_handler.py
+++ b/tests/unit_tests/test_node_handler.py
@@ -88,6 +88,7 @@ def test_create_node_endpoint(mock_db_create, mock_publish_cloudevent,
         'updated',
         'user_groups',
         'processed_by_kcidb_bridge',
+        'retry_counter',
     }
 
 
@@ -249,6 +250,7 @@ def test_get_node_by_id_endpoint(mock_db_find_by_id,
         'updated',
         'user_groups',
         'processed_by_kcidb_bridge',
+        'retry_counter',
     }
 
 

--- a/tests/unit_tests/test_node_handler.py
+++ b/tests/unit_tests/test_node_handler.py
@@ -87,6 +87,7 @@ def test_create_node_endpoint(mock_db_create, mock_publish_cloudevent,
         'treeid',
         'updated',
         'user_groups',
+        'processed_by_kcidb_bridge',
     }
 
 
@@ -247,6 +248,7 @@ def test_get_node_by_id_endpoint(mock_db_find_by_id,
         'treeid',
         'updated',
         'user_groups',
+        'processed_by_kcidb_bridge',
     }
 
 


### PR DESCRIPTION
Changes (https://github.com/kernelci/kernelci-core/pull/2746 and https://github.com/kernelci/kernelci-core/pull/2927) to the model caused unit tests to get out-of-sync with its new state.

Tests adjusted in this patch should be kept in sync with [Node class from "kernelci/api/models.py" in "kernelci/kernelci-core" repo](https://github.com/kernelci/kernelci-core/blob/ee64d7e4cdaeef2176d9755c9112ff97c8ad8e3a/kernelci/api/models.py#L184)