### PR TITLE
docker-compose: remove obsolete 'version' attribute

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -3,7 +3,6 @@
 # Copyright (C) 2021 Collabora Limited
 # Author: Guillaume Tucker <guillaume.tucker@collabora.com>
 
-version: '3'
 services:
 
   api:


### PR DESCRIPTION
Fix this warning:
WARN[0000] kernelci-api/docker-compose.yaml: the attribute `version` is obsolete, it will be ignored, please remove it to avoid potential confusion