### PR TITLE
fix: autoremove admin user creation ephemeral container

### DIFF
--- a/scripts/setup_admin_user
+++ b/scripts/setup_admin_user
@@ -10,6 +10,6 @@ fi
 
 set -e
 
-${DOCKER_COMPOSE} run api python3 -m api.admin $*
+${DOCKER_COMPOSE} run --rm api python3 -m api.admin $*
 
 exit 0


### PR DESCRIPTION
This PR prevents dangling containers (e.g. `kernelci-api-api-run-2e5cf347e346`) when setting up the admin user using `scripts/setup_admin_user` script.
