### PR TITLE
fix docker compose volume mounts

### DIFF
--- a/dev-docker-compose.yaml
+++ b/dev-docker-compose.yaml
@@ -43,7 +43,7 @@ services:
     image: 'nginx:1.21.3'
     volumes:
       - './docker/storage/data:/usr/share/nginx/html'
-      - './docker/storage/config/default.conf:/etc/nginx/conf.d/default.conf'
+      - './docker/storage/config/:/etc/nginx/conf.d'
     ports:
       - ${STORAGE_HOST_PORT:-8002}:80
 

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -40,7 +40,7 @@ services:
     image: 'nginx:1.21.3'
     volumes:
       - './docker/storage/data:/usr/share/nginx/html'
-      - './docker/storage/config/default.conf:/etc/nginx/conf.d/default.conf'
+      - './docker/storage/config/:/etc/nginx/conf.d'
     ports:
       - ${STORAGE_HOST_PORT:-8002}:80
 


### PR DESCRIPTION
This PR fixes the following error, arising when starting the `docker-compose.yaml` or `dev-docker-compose.yaml` files:

"Error response from daemon: failed to create task for container: failed to create shim task: OCI runtime create failed: runc create failed: unable to start container process: error during container init: error mounting "/home/kernelci/kernelci/kernelci-api/docker/storage/config/default.conf" to rootfs at "/etc/nginx/conf.d/default.conf": create mountpoint for /etc/nginx/conf.d/default.conf mount: cannot create subdirectories in "/var/lib/docker/overlay2/755b51189a335c2b25bbfd77c32fd44dcc0b5c93159a347e6852c851124716dc/merged/etc/nginx/conf.d/default.conf": not a directory: unknown: Are you trying to mount a directory onto a file (or vice-versa)? Check if the specified host path exists and is the expected type"

```
docker --version
Docker version 28.0.4, build b8034c0
```