### PR TITLE
(main.py) Make KernelCI system users as superusers

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -16,7 +16,7 @@ on:
 
 jobs:
   check:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
 
     strategy:
       matrix:
@@ -51,10 +51,14 @@ jobs:
         run: |
           export DEBIAN_FRONTEND=noninteractive
           sudo apt-get update
-          sudo apt-get install -y docker-compose docker.io
+          sudo apt install apt-transport-https ca-certificates curl software-properties-common -y
+          curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo apt-key add -          
+          sudo add-apt-repository "deb [arch=amd64] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable"
+          sudo apt-get update
+          sudo apt install docker-ce docker-ce-cli containerd.io -y
 
       - name: Build docker images
-        run: docker-compose -f test-docker-compose.yaml build --no-cache
+        run: docker compose -f test-docker-compose.yaml build --no-cache
 
       - name: Run pycodestyle
         run: |
@@ -62,18 +66,18 @@ jobs:
 
       - name: Run API containers
         run: |
-          docker-compose -f test-docker-compose.yaml up -d test
+          docker compose -f test-docker-compose.yaml up -d test
 
       - name: Run pylint
         run: |
-          docker-compose -f test-docker-compose.yaml exec -T test pylint --extension-pkg-whitelist=pydantic api/
-          docker-compose -f test-docker-compose.yaml exec -T test pylint tests/unit_tests
-          docker-compose -f test-docker-compose.yaml exec -T test pylint tests/e2e_tests
+          docker compose -f test-docker-compose.yaml exec -T test pylint --extension-pkg-whitelist=pydantic api/
+          docker compose -f test-docker-compose.yaml exec -T test pylint tests/unit_tests
+          docker compose -f test-docker-compose.yaml exec -T test pylint tests/e2e_tests
 
       - name: Stop docker containers
         if: always()
         run: |
-          docker-compose -f test-docker-compose.yaml down
+          docker compose -f test-docker-compose.yaml down
 
   lint:
     runs-on: ubuntu-22.04

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -101,7 +101,7 @@ jobs:
           pip install -r docker/api/requirements-tests.txt
 
       - if: env.CHANGED_FILES
-        uses: marian-code/python-lint-annotate@v3
+        uses: marian-code/python-lint-annotate@v4
         with:
           python-root-list: ${{ env.CHANGED_FILES }}
           use-black: false

--- a/api/main.py
+++ b/api/main.py
@@ -334,6 +334,10 @@ async def authorize_user(node_id: str,
             status_code=status.HTTP_404_NOT_FOUND,
             detail=f"Node not found with id: {node_id}"
         )
+    # users staging.kernelci.org and production are superusers
+    # TBD: This is HACK until qualcomm can migrate to direct KCIDB
+    if user.username in ['staging.kernelci.org', 'production']:
+        return user
     if not user.username == node_from_id.owner:
         if not any(group.name in node_from_id.user_groups
                    for group in user.groups):


### PR DESCRIPTION
Superusers can update others nodes, for example needed if kcidb bridge are processing other user nodes.
This is temporary hack to make sure qualcomm setup works.