### PR TITLE
(k8s) Change policy on mongodb volume to Retain

### DIFF
--- a/kube/aks/ingress.yaml
+++ b/kube/aks/ingress.yaml
@@ -13,6 +13,9 @@ metadata:
   namespace: kernelci-api
   annotations:
     cert-manager.io/cluster-issuer: all-issuer
+    nginx.ingress.kubernetes.io/compression-level: "6"  # 1-9, higher = better compression
+    nginx.ingress.kubernetes.io/compression-types: "application/json text/html text/plain application/javascript text/css application/x-javascript"  # MIME types to compress
+    nginx.ingress.kubernetes.io/compression-min-length: "1000"  # bytes
 spec:
   ingressClassName: ingressclass-api
   tls:

--- a/kube/aks/mongo.yaml
+++ b/kube/aks/mongo.yaml
@@ -97,6 +97,6 @@ spec:
           operator: In
           values:
           - ""
-  persistentVolumeReclaimPolicy: Delete
+  persistentVolumeReclaimPolicy: Retain
   storageClassName: managed-csi-premium
   volumeMode: Filesystem


### PR DESCRIPTION
In case of mistake, if pv/pvc deleted better to change policy to Retain, so we can recover the data.