### PR TITLE
api.db: enable `in` and `nin` query operators

### DIFF
--- a/api/db.py
+++ b/api/db.py
@@ -37,6 +37,8 @@ class Database:
         'gte': '$gte',
         'ne': '$ne',
         're': '$regex',
+        'in': '$in',
+        'nin': '$nin',
     }
 
     BOOL_VALUE_MAP = {
@@ -138,6 +140,9 @@ class Database:
                 for op_name, op_value in value.items():
                     op_key = self.OPERATOR_MAP.get(op_name)
                     if op_key:
+                        if op_key in ('$in', '$nin'):
+                            # Create a list of values from ',' separated string
+                            op_value = op_value.split(",")
                         if isinstance(op_value, str) and op_value.isdecimal():
                             op_value = int(op_value)
                         if translated_attributes.get(key):


### PR DESCRIPTION
`in` operator: Enable support for query operator to return documents by matching field value from a list of multiple values.
For instance nodes with state `running` and `done` can be retrieved by the following request:
`http://API_URL/nodes?state__in=running,done`
Multiple values should be comma-separated in the
request URL.

`nin` operator: Enable support for query operator to return documents that do not match any of the field value from a list of multiple values.
For instance nodes with state other than `running` and `done` can be retrieved by the following request:
`http://API_URL/nodes?state__nin=running,done`
Multiple values should be comma-separated in the
request URL just as `in` operator.