### PR TITLE
template/stats: Make limit configurable

### DIFF
--- a/api/templates/stats.html
+++ b/api/templates/stats.html
@@ -125,7 +125,7 @@
             <div class="form-section">
                 <h3 class="mb-3"><i class="bi bi-sliders"></i> Filter Options</h3>
                 <div class="row">
-                    <div class="col-md-4 mb-3">
+                    <div class="col-md-3 mb-3">
                         <label for="duration" class="form-label">Duration</label>
                         <select class="form-select" id="duration">
                             <option value="24h">Last 24 hours</option>
@@ -133,7 +133,7 @@
                             <option value="7d">Last 7 days</option>
                         </select>
                     </div>
-                    <div class="col-md-4 mb-3">
+                    <div class="col-md-3 mb-3">
                         <label for="kind" class="form-label">Kind</label>
                         <select class="form-select" id="kind">
                             <option value="kbuild">Kernel Builds</option>
@@ -141,7 +141,17 @@
                             <option value="checkout">Checkouts</option>
                         </select>
                     </div>
-                    <div class="col-md-4 mb-3 d-flex align-items-end">
+                    <div class="col-md-3 mb-3">
+                        <label for="limit" class="form-label">Limit</label>
+                        <select class="form-select" id="limit">
+                            <option value="1000" selected>1,000</option>
+                            <option value="10000">10,000</option>
+                            <option value="20000">20,000</option>
+                            <option value="30000">30,000</option>
+                            <option value="100000">100,000</option>
+                        </select>
+                    </div>
+                    <div class="col-md-6 mb-3 d-flex align-items-end">
                         <button type="button" class="btn btn-generate btn-primary w-100" id="generateBtn">
                             <i class="bi bi-play-circle"></i> Generate Statistics
                         </button>
@@ -303,6 +313,7 @@
         function generateStatistics() {
             var duration = $('#duration').val();
             var kind = $('#kind').val();
+            var limit = $('#limit').val();
             
             showLoading();
             
@@ -310,7 +321,7 @@
             var dateFilter = getDurationFilter(duration);
             var url = apiurl + '/latest/nodes?kind=' + encodeURIComponent(kind) + 
                      '&created__gt=' + encodeURIComponent(dateFilter) + 
-                     '&limit=1000';
+                     '&limit=' + encodeURIComponent(limit);
             
             console.log('Fetching statistics from:', url);
             


### PR DESCRIPTION
Turned out, on production we have almost 1000 builds per week, so default is not enough. Let's make few options more.