### PR TITLE
Fix `/docs` endpoint

### DIFF
--- a/docker/api/requirements.txt
+++ b/docker/api/requirements.txt
@@ -1,4 +1,5 @@
 cloudevents==1.9.0
+beanie == 1.29.0
 fastapi[all]==0.115.0
 fastapi-pagination==0.12.30
 fastapi-users[beanie, oauth]==13.0.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ requires-python = ">=3.10"
 license = {text = "LGPL-2.1-or-later"}
 dependencies = [
   "cloudevents == 1.9.0",
-  "beanie == 1.28.0",
+  "beanie == 1.29.0",
   "fastapi[all] == 0.115.0",
   "fastapi-pagination == 0.12.30",
   "fastapi-users[beanie, oauth] == 14.0.0",


### PR DESCRIPTION
Upgrade `beanie` version to fix the below error:
```
Exception: Cannot generate a JsonSchema for
core_schema.PlainValidatorFunctionSchema
({'type': 'with-info', 'function': <bound method PydanticObjectId.validate of
<class 'beanie.odm.fields.PydanticObjectId'>>})
```
Beanie release note states that `1.29.0` version fix above error.
Reference link: https://github.com/BeanieODM/beanie/releases/tag/1.29.0