### PR TITLE
dependencies:  Updated python-jose from 3.3.0 to 3.5.0 due CVE

### DIFF
--- a/docker/api/requirements.txt
+++ b/docker/api/requirements.txt
@@ -10,6 +10,6 @@ pymongo==4.9.0
 passlib==1.7.4
 pydantic==2.9.2
 pymongo-migrate==0.11.0
-python-jose[cryptography]==3.3.0
+python-jose[cryptography]==3.5.0
 redis==5.0.1
 uvicorn[standard]==0.29.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ dependencies = [
   "passlib == 1.7.4",
   "pydantic == 2.9.2",
   "pymongo-migrate == 0.11.0",
-  "python-jose[cryptography] == 3.3.0",
+  "python-jose[cryptography] == 3.5.0",
   "redis == 5.0.1",
   "uvicorn[standard] == 0.29.0",
 ]


### PR DESCRIPTION
CVE-2024-33663 Critical severity
CVE-2024-33664 Moderate severity

They don't affect us, but it is better to be on safe side.