### PR TITLE
Pin checkout action and document unified secret deployment

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,7 +25,7 @@ jobs:
     steps:
 
       - name: Check out source code
-        uses: actions/checkout@v2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Export environment variables
         run: |

--- a/doc/local-instance.md
+++ b/doc/local-instance.md
@@ -53,6 +53,28 @@ $ echo MONGO_SERVICE=mongodb://db:27017 >> .env
 `SECRET_KEY` and `MONGO_SERVICE` are always required.
 `KCI_INITIAL_PASSWORD` is required only when no admin user exists yet.
 
+#### Unified secret (shared across KernelCI services)
+
+The API can additionally accept JWTs signed with a shared HS256 key called
+`UNIFIED_SECRET`.  When set, each incoming token is validated against
+`SECRET_KEY` first and falls back to `UNIFIED_SECRET` on signature failure
+(see `DualSecretJWTStrategy` in `api/auth.py`).  The same key is installed
+on `kernelci-pipeline` (`[jwt].unified_secret`), `kernelci-storage`
+(`unified_secret` in its TOML) and `kcidb-restd-rs` (`--unified-secret` /
+`UNIFIED_SECRET`), so a single token authenticates a user across all four
+services.
+
+Generate it the same way as `SECRET_KEY`:
+
+```
+$ echo UNIFIED_SECRET=$(openssl rand -hex 32) >> .env
+```
+
+`UNIFIED_SECRET` is optional; leave it unset to disable the fallback.  The
+full token spec, per-service claim validation, and step-by-step deployment
+migration are documented in `UNIFIED_TOKEN.md` in the `kernelci-deploy`
+repository.
+
 ### Start docker-compose
 
 To build the Docker images and start `docker-compose`:

--- a/env.sample
+++ b/env.sample
@@ -1,4 +1,11 @@
 SECRET_KEY=
+# Optional second HS256 key accepted as a fallback on token verification.
+# When set, the API tries SECRET_KEY first and UNIFIED_SECRET on signature
+# failure, so a single JWT can authenticate the user across all KernelCI
+# services (api, pipeline lava-callback, storage, kcidb-restd-rs).  The same
+# value must be installed on each service.  See UNIFIED_TOKEN.md in the
+# kernelci-deploy repo for the full spec and migration steps.
+UNIFIED_SECRET=
 MONGO_SERVICE=mongodb://db:27017
 #algorithm=
 #access_token_expire_minutes=

--- a/kube/aks/api.yaml
+++ b/kube/aks/api.yaml
@@ -50,6 +50,15 @@ spec:
                 secretKeyRef:
                   name: kernelci-api-secret
                   key: secret-key
+            # Optional unified HS256 key shared with kernelci-pipeline,
+            # kernelci-storage and kcidb-restd-rs.  Add a `unified-secret`
+            # key to the kernelci-api-secret Secret to enable.
+            - name: UNIFIED_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: kernelci-api-secret
+                  key: unified-secret
+                  optional: true
             - name: EMAIL_SENDER
               valueFrom:
                 configMapKeyRef:


### PR DESCRIPTION
## Summary
- pin `actions/checkout` in the test workflow to the same v6.0.2 commit used elsewhere
- document `UNIFIED_SECRET` in the sample env and local setup guide
- add the optional `UNIFIED_SECRET` secret reference to the AKS API deployment

## Notes
- keeps the workflow pinning change separate from the unified secret deployment/doc updates at the commit level